### PR TITLE
Fix snapping scroll in list view

### DIFF
--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -2936,10 +2936,10 @@ input:checked + .slider:before {
 .snap-container {
   height: var(--app-height, 100vh);
   overflow-y: auto;
-  scroll-snap-type: y mandatory;
+  /* Disable mandatory snap so list view scrolls freely */
+  scroll-snap-type: none;
   scroll-behavior: smooth;
   position: relative;
-  /* Enable smooth scrolling with scroll-snap */
   -webkit-overflow-scrolling: touch;
 }
 


### PR DESCRIPTION
## Summary
- disable mandatory snap behaviour so the shift list scrolls freely

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68680a83cc08832f94ed9c9c25476b69