### PR TITLE
Add toggle between shift list and calendar view

### DIFF
--- a/kalkulator/app.html
+++ b/kalkulator/app.html
@@ -114,6 +114,10 @@
               <div class="app-container">
                   <div class="section-header">
                       <h2>Vakter</h2>
+                      <div class="tab-nav view-toggle">
+                          <button class="tab-btn active" onclick="app.switchShiftView('list')">Liste</button>
+                          <button class="tab-btn" onclick="app.switchShiftView('calendar')">Kalender</button>
+                      </div>
                       <button class="settings-btn" onclick="app.openAddShiftModal()">
                           <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                               <circle cx="12" cy="12" r="10"></circle>
@@ -137,6 +141,7 @@
                           <p>Ingen vakter registrert ennå</p>
                       </div>
                   </div>
+                  <div id="shiftCalendar" class="shift-calendar" style="display:none;"></div>
                   <footer class="app-footer">
                       Laget av <a href="https://github.com/kkarlsen-productions" target="_blank" style="color:var(--accent);text-decoration:none;">Hjalmar Samuel Kristensen-Karlsen</a> &middot; 2025
                   </footer>

--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -920,6 +920,16 @@ input[type="time"].form-control[value=""]:focus {
   display: block;
 }
 
+/* View toggle in shift section */
+.view-toggle {
+  margin-left: auto;
+  margin-right: 12px;
+}
+.view-toggle .tab-btn {
+  padding: 8px 12px;
+  font-size: 13px;
+}
+
 /* Recurring Feature Introduction Modal */
 #recurringIntroModal {
   display: flex;
@@ -1725,6 +1735,8 @@ input:checked + .slider:before {
   grid-template-columns: 32px repeat(7, 1fr);
   gap: 2px;
   margin-bottom: 2px;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .calendar-day-header {
@@ -1740,6 +1752,8 @@ input:checked + .slider:before {
   grid-template-columns: 32px repeat(7, 1fr);
   gap: 2px;
   flex: 1;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .calendar-cell {
@@ -1850,6 +1864,34 @@ input:checked + .slider:before {
   max-width: 100%;
   display: block;
   width: 100%;
+}
+
+/* Shift calendar customizations */
+.shift-calendar {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0 4px 20px 4px;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+.shift-calendar .calendar-cell,
+.shift-calendar .calendar-week-number {
+  min-height: 65px;
+}
+.calendar-breakdown {
+  font-size: clamp(9px, 2.3vw, 13px);
+  color: var(--text-secondary);
+  line-height: 1.1;
+  display: flex;
+  flex-direction: column;
+}
+.calendar-total {
+  font-size: clamp(10px, 2.5vw, 14px);
+  font-weight: 700;
+  color: var(--accent4);
+  line-height: 1;
 }
 
 /* Responsive calendar adjustments */


### PR DESCRIPTION
## Summary
- add list/calendar toggle buttons to shift section
- implement calendar rendering for shifts with daily totals
- update display logic to support new calendar view
- tweak styling for new toggle and calendar layout
- ensure calendar width fits viewport and bonus is shown on a new line

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68680760eb78832fbee89f32aef794d2