### PR TITLE
Update top bar layout

### DIFF
--- a/kalkulator/app.html
+++ b/kalkulator/app.html
@@ -21,13 +21,29 @@
                       <!-- Top row: navigation buttons -->
                       <div class="header-top">
                           <div class="header-left">
-                              <a href="/" class="header-back-btn">
-                                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                      <path d="m12 19-7-7 7-7"/>
-                                      <path d="M19 12H5"/>
+                              <span>
+                                  <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                      <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                                      <line x1="16" y1="2" x2="16" y2="6"></line>
+                                      <line x1="8" y1="2" x2="8" y2="6"></line>
+                                      <line x1="3" y1="10" x2="21" y2="10"></line>
                                   </svg>
-                                  Hovedside
-                              </a>
+                                  <div class="month-selector">
+                                      <button class="month-button" onclick="app.toggleMonthDropdown()">
+                                          <span id="currentMonth">Mai 2025</span>
+                                          <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                              <polyline points="6 9 12 15 18 9"></polyline>
+                                          </svg>
+                                      </button>
+                                  </div>
+                              </span>
+                              <span>
+                                  <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                      <circle cx="12" cy="12" r="10"></circle>
+                                      <path d="M12 6v6l4 2"></path>
+                                  </svg>
+                                  <span id="currentWage">184,54 kr/t</span>
+                              </span>
                           </div>
                           <div class="header-right">
                                 <button class="settings-btn" onclick="app.openSettings()">
@@ -41,29 +57,6 @@
                           </div>
                       </div>
                       <div class="header-info">
-                          <span>
-                              <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                  <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-                                  <line x1="16" y1="2" x2="16" y2="6"></line>
-                                  <line x1="8" y1="2" x2="8" y2="6"></line>
-                                  <line x1="3" y1="10" x2="21" y2="10"></line>
-                              </svg>
-                              <div class="month-selector">
-                                  <button class="month-button" onclick="app.toggleMonthDropdown()">
-                                      <span id="currentMonth">Mai 2025</span>
-                                      <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                          <polyline points="6 9 12 15 18 9"></polyline>
-                                      </svg>
-                                  </button>
-                              </div>
-                          </span>
-                          <span>
-                              <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                  <circle cx="12" cy="12" r="10"></circle>
-                                  <path d="M12 6v6l4 2"></path>
-                              </svg>
-                              <span id="currentWage">184,54 kr/t</span>
-                          </span>
                           <div id="userEmailContainer" style="display: none;">
                               <button id="emailToggleBtn" class="email-toggle-btn" onclick="app.toggleEmailDisplay()">
                                   <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -280,12 +280,12 @@ body {
 
 .header {
   background: linear-gradient(135deg, var(--bg-secondary), var(--bg-tertiary));
-  padding: 20px;
+  padding: 12px 20px;
   border-bottom: 1px solid var(--border);
   border-radius: 0 0 16px 16px;
   transition: transform 0.4s var(--ease-default), opacity 0.3s var(--ease-default);
   overflow: visible;
-  min-height: 80px; /* Fixed minimum height to prevent layout shift */
+  min-height: 60px; /* Reduced height for slimmer top bar */
   flex-shrink: 0;
 }
 
@@ -300,12 +300,13 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
 }
 
 .header-left {
   display: flex;
   align-items: center;
+  gap: 12px;
 }
 
 .header-right {


### PR DESCRIPTION
## Summary
- move month selector and current wage into the main header
- remove home link
- keep email toggle below new slim top bar
- adjust header styles for a thinner bar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868111dd51c832f93efa52e62c670f6