### PR TITLE
Add delta label under total

### DIFF
--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -1462,6 +1462,15 @@ input:checked + .slider:before {
   font-size: 14px;
   margin-bottom: 10px;
 }
+.delta-arrow {
+  margin-right: 4px;
+}
+.delta-positive {
+  color: var(--success);
+}
+.delta-negative {
+  color: var(--danger);
+}
 .total-amount {
   font-size: 48px;
   font-weight: 700;

--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -1921,6 +1921,27 @@ export const app = {
         document.getElementById('baseAmount').textContent = this.formatCurrency(totalBase);
         document.getElementById('bonusAmount').textContent = this.formatCurrency(totalBonus);
         document.getElementById('shiftCount').textContent = monthShifts.length;
+
+        // Calculate delta versus previous month for the total card label
+        const deltaLabelEl = document.querySelector('.total-label');
+        if (deltaLabelEl) {
+            const prevMonth = this.currentMonth === 1 ? 12 : this.currentMonth - 1;
+            const prevYear = this.currentMonth === 1 ? this.YEAR - 1 : this.YEAR;
+            const prevShifts = this.shifts.filter(s =>
+                s.date.getMonth() === prevMonth - 1 &&
+                s.date.getFullYear() === prevYear
+            );
+            let prevTotal = 0;
+            prevShifts.forEach(s => { prevTotal += this.calculateShift(s).total; });
+            let deltaPercent = 0;
+            if (prevTotal > 0) {
+                deltaPercent = ((totalAmount - prevTotal) / prevTotal) * 100;
+            }
+            const arrow = deltaPercent >= 0 ? '▲' : '▼';
+            const arrowClass = deltaPercent >= 0 ? 'delta-positive' : 'delta-negative';
+            const prevMonthName = this.MONTHS[prevMonth - 1];
+            deltaLabelEl.innerHTML = `<span class="delta-arrow ${arrowClass}">${arrow}</span> ${Math.abs(deltaPercent).toFixed(1)} % vs. ${prevMonthName}`;
+        }
         // Oppdater fremdriftslinje for månedlig inntektsmål
         const monthlyGoal = getMonthlyGoal();
         updateProgressBar(totalAmount, monthlyGoal, shouldAnimate);


### PR DESCRIPTION
## Summary
- compute monthly delta in `updateStats`
- replace `Brutto` label on the total card with `▲/▼ x % vs. [forrige måned]`
- color the arrow green for increases and red for decreases using CSS variables

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868116e3e1c832f99a723150a04ba7f