### PR TITLE
Slim header and repositioned controls

### DIFF
--- a/kalkulator/app.html
+++ b/kalkulator/app.html
@@ -21,49 +21,36 @@
                       <!-- Top row: navigation buttons -->
                       <div class="header-top">
                           <div class="header-left">
-                              <a href="/" class="header-back-btn">
-                                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                      <path d="m12 19-7-7 7-7"/>
-                                      <path d="M19 12H5"/>
+                              <span>
+                                  <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                      <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                                      <line x1="16" y1="2" x2="16" y2="6"></line>
+                                      <line x1="8" y1="2" x2="8" y2="6"></line>
+                                      <line x1="3" y1="10" x2="21" y2="10"></line>
                                   </svg>
-                                  Hovedside
-                              </a>
+                                  <div class="month-selector">
+                                      <button class="month-button" onclick="app.toggleMonthDropdown()">
+                                          <span id="currentMonth">Mai 2025</span>
+                                          <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                              <polyline points="6 9 12 15 18 9"></polyline>
+                                          </svg>
+                                      </button>
+                                  </div>
+                              </span>
+                              <span>
+                                  <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                      <circle cx="12" cy="12" r="10"></circle>
+                                      <path d="M12 6v6l4 2"></path>
+                                  </svg>
+                                  <span id="currentWage">184,54 kr/t</span>
+                              </span>
                           </div>
                           <div class="header-right">
-                                <button class="settings-btn" onclick="app.openSettings()">
-                                    <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                        <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path>
-                                        <circle cx="12" cy="12" r="3"></circle>
-                                    </svg>
-                                    <span>Innstillinger</span>
-                                </button>
+                                <button class="settings-btn" onclick="app.openSettings()">Innstillinger</button>
                                 <button class="settings-btn" onclick="logout()">Logg&nbsp;ut</button>
                           </div>
                       </div>
                       <div class="header-info">
-                          <span>
-                              <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                  <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-                                  <line x1="16" y1="2" x2="16" y2="6"></line>
-                                  <line x1="8" y1="2" x2="8" y2="6"></line>
-                                  <line x1="3" y1="10" x2="21" y2="10"></line>
-                              </svg>
-                              <div class="month-selector">
-                                  <button class="month-button" onclick="app.toggleMonthDropdown()">
-                                      <span id="currentMonth">Mai 2025</span>
-                                      <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                          <polyline points="6 9 12 15 18 9"></polyline>
-                                      </svg>
-                                  </button>
-                              </div>
-                          </span>
-                          <span>
-                              <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                  <circle cx="12" cy="12" r="10"></circle>
-                                  <path d="M12 6v6l4 2"></path>
-                              </svg>
-                              <span id="currentWage">184,54 kr/t</span>
-                          </span>
                           <div id="userEmailContainer" style="display: none;">
                               <button id="emailToggleBtn" class="email-toggle-btn" onclick="app.toggleEmailDisplay()">
                                   <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -280,12 +280,12 @@ body {
 
 .header {
   background: linear-gradient(135deg, var(--bg-secondary), var(--bg-tertiary));
-  padding: 20px;
+  padding: 4px 16px;
   border-bottom: 1px solid var(--border);
   border-radius: 0 0 16px 16px;
   transition: transform 0.4s var(--ease-default), opacity 0.3s var(--ease-default);
   overflow: visible;
-  min-height: 80px; /* Fixed minimum height to prevent layout shift */
+  min-height: 48px; /* Smaller height for slim top bar */
   flex-shrink: 0;
 }
 
@@ -300,18 +300,36 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 16px;
+  margin-bottom: 2px;
 }
 
 .header-left {
   display: flex;
   align-items: center;
+  gap: 8px;
+}
+
+/* Maintain styling for month selector and wage in header-left */
+.header-left span {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.header-left span svg.icon-sm {
+  width: 14px;
+  height: 14px;
 }
 
 .header-right {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
+}
+.header-right .settings-btn {
+  padding: 4px 10px;
+  font-size: 13px;
 }
 
 .header-back-btn {
@@ -409,8 +427,8 @@ body {
   align-items: center;
   width: 100%;
   position: relative;
-  overflow: visible; /* Change from hidden to visible to prevent clipping */
-  height: 20px; /* Fixed height to prevent layout shift */
+  overflow: visible; /* Keep visible to prevent clipping */
+  height: 14px; /* Slightly smaller for slim header */
   flex-shrink: 0; /* Prevent shrinking */
 }
 
@@ -433,11 +451,11 @@ body {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 5px;
-  padding: 4px 8px;
+  gap: 4px;
+  padding: 2px 6px;
   border-radius: 6px;
   transition: all var(--speed-normal) var(--ease-default);
-  font-size: 14px;
+  font-size: 12px;
 }
 
 .month-button:hover {


### PR DESCRIPTION
## Summary
- reduce header padding and height
- make month selector and wage display smaller
- remove settings gear icon and narrow the buttons

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6868111dd51c832f93efa52e62c670f6