### PR TITLE
Fix settings modal height

### DIFF
--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -806,7 +806,7 @@ input[type="time"].form-control[value=""]:focus {
   z-index: 1300;
   max-width: 480px;
   width: 90vw;
-  max-height: 80vh;
+  max-height: 90vh;
   overflow-y: auto;
   border-radius: 16px;
   box-shadow: 0 16px 48px -12px var(--shadow-accent);
@@ -824,7 +824,7 @@ input[type="time"].form-control[value=""]:focus {
 #settingsModal .modal-content {
   min-height: auto;
   height: auto;
-  max-height: 80vh;
+  max-height: 90vh;
 }
 
 /* Hide scrollbars in modals while keeping scroll functionality */

--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -1622,7 +1622,7 @@ export const app = {
         
         // Temporarily reset height to auto to get accurate measurements
         modalContent.style.height = 'auto';
-        modalContent.style.maxHeight = '80vh';
+        modalContent.style.maxHeight = '90vh';
         
         // Small delay to ensure DOM has updated
         requestAnimationFrame(() => {
@@ -1640,7 +1640,7 @@ export const app = {
                 
                 // Set reasonable limits
                 const minHeight = 250;
-                const maxHeight = Math.floor(window.innerHeight * 0.8); // 80vh
+                const maxHeight = Math.floor(window.innerHeight * 0.9); // 90vh
                 
                 finalHeight = Math.min(Math.max(totalNeededHeight, minHeight), maxHeight);
                 


### PR DESCRIPTION
## Summary
- relax settings modal max-height so more vertical space is used
- align dynamic JS logic with new 90vh limit

## Testing
- `grep -n "80vh" -n kalkulator/js/appLogic.js`


------
https://chatgpt.com/codex/tasks/task_e_6868213fae38832f875db4c055083be7