### PR TITLE
Add stat detail modal

### DIFF
--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -3110,6 +3110,11 @@ input:checked + .slider:before {
   flex-direction: column;
   justify-content: center;
   gap: 4px;
+  cursor: pointer;
+  transition: transform var(--speed-normal) var(--ease-default);
+}
+.stat-card:hover {
+  transform: var(--lift-small);
 }
 
 .stat-value {


### PR DESCRIPTION
## Summary
- make stat cards interactive
- display breakdown in a popup when tapping a stat card
- add hover effects for stat cards

## Testing
- `node --check kalkulator/js/appLogic.js`

------
https://chatgpt.com/codex/tasks/task_e_6868168f2d38832f85919a07eca9332f