### PR TITLE
Simplify app header

### DIFF
--- a/kalkulator/app.html
+++ b/kalkulator/app.html
@@ -18,16 +18,16 @@
           <section class="snap-section dashboard-section">
               <div class="app-container">
                   <div class="header">
-                      <!-- Top row: navigation buttons -->
                       <div class="header-top">
                           <div class="header-left">
-                              <a href="/" class="header-back-btn">
-                                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                      <path d="m12 19-7-7 7-7"/>
-                                      <path d="M19 12H5"/>
-                                  </svg>
-                                  Hovedside
-                              </a>
+                              <div class="month-selector">
+                                  <button class="month-button" onclick="app.toggleMonthDropdown()">
+                                      <span id="currentMonth">Mai 2025</span>
+                                      <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                          <polyline points="6 9 12 15 18 9"></polyline>
+                                      </svg>
+                                  </button>
+                              </div>
                           </div>
                           <div class="header-right">
                                 <button class="settings-btn" onclick="app.openSettings()">
@@ -37,43 +37,6 @@
                                     </svg>
                                     <span>Innstillinger</span>
                                 </button>
-                                <button class="settings-btn" onclick="logout()">Logg&nbsp;ut</button>
-                          </div>
-                      </div>
-                      <div class="header-info">
-                          <span>
-                              <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                  <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-                                  <line x1="16" y1="2" x2="16" y2="6"></line>
-                                  <line x1="8" y1="2" x2="8" y2="6"></line>
-                                  <line x1="3" y1="10" x2="21" y2="10"></line>
-                              </svg>
-                              <div class="month-selector">
-                                  <button class="month-button" onclick="app.toggleMonthDropdown()">
-                                      <span id="currentMonth">Mai 2025</span>
-                                      <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                          <polyline points="6 9 12 15 18 9"></polyline>
-                                      </svg>
-                                  </button>
-                              </div>
-                          </span>
-                          <span>
-                              <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                  <circle cx="12" cy="12" r="10"></circle>
-                                  <path d="M12 6v6l4 2"></path>
-                              </svg>
-                              <span id="currentWage">184,54 kr/t</span>
-                          </span>
-                          <div id="userEmailContainer" style="display: none;">
-                              <button id="emailToggleBtn" class="email-toggle-btn" onclick="app.toggleEmailDisplay()">
-                                  <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                      <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
-                                      <polyline points="22,6 12,13 2,6"></polyline>
-                                  </svg>
-                              </button>
-                              <span id="userEmailDisplay" class="user-email-text" style="display: none;">
-                                  <span id="userEmail" class="email-inner-text"></span>
-                              </span>
                           </div>
                       </div>
                   </div>
@@ -299,6 +262,9 @@
                   </div>
                   
                   <p id="profile-update-msg" style="color: var(--success); min-height: 24px; text-align: center; font-size: 14px;"></p>
+                  <div class="form-group">
+                      <button class="btn btn-secondary" onclick="logout()">Logg ut</button>
+                  </div>
               </div>
 
               <div id="dataTab" class="tab-content">

--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -300,7 +300,7 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 16px;
+  margin-bottom: 0;
 }
 
 .header-left {

--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -1879,13 +1879,8 @@ export const app = {
         this.updateShiftCalendar();
     },
     updateHeader() {
-        let wage = this.getCurrentWageRate();
-        if (typeof wage !== 'number' || isNaN(wage)) {
-            wage = 0;
-        }
         const monthName = this.MONTHS[this.currentMonth - 1].charAt(0).toUpperCase() + this.MONTHS[this.currentMonth - 1].slice(1);
         document.getElementById('currentMonth').textContent = `${monthName} ${this.YEAR}`;
-        document.getElementById('currentWage').textContent = `${wage.toFixed(2).replace('.', ',')} kr/t`;
         
         // Update the total card label to match selected month
         const totalLabel = document.querySelector('.total-label');


### PR DESCRIPTION
## Summary
- remove back button and wage display from header
- move month selector next to settings button
- add logout button to settings
- adjust header CSS

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686821bdda18832f854191e219766b53