### PR TITLE
Fix stat cards clipping

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -2046,6 +2046,7 @@ export const app = {
         container.innerHTML = '';
 
         const viewport = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+        const shiftSection = document.querySelector('.shift-section');
 
         for (const s of stats) {
             const card = document.createElement('div');
@@ -2055,7 +2056,8 @@ export const app = {
             card.addEventListener('click', () => this.showStatDetails(s.id));
             container.appendChild(card);
 
-            if (container.getBoundingClientRect().bottom > viewport) {
+            const cutoff = Math.min(viewport, shiftSection ? shiftSection.getBoundingClientRect().top : viewport);
+            if (card.getBoundingClientRect().bottom > cutoff) {
                 container.removeChild(card);
                 break;
             }


### PR DESCRIPTION
## Summary
- ensure stat cards stop rendering if they would overlap the shift list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68682b3600f0832f845943e24a7d7b2b