### PR TITLE
Fix stat card overflow detection

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -2057,7 +2057,7 @@ export const app = {
             container.appendChild(card);
 
             const cutoff = Math.min(viewport, shiftSection ? shiftSection.getBoundingClientRect().top : viewport);
-            if (card.getBoundingClientRect().bottom > cutoff) {
+            if (container.getBoundingClientRect().bottom > cutoff) {
                 container.removeChild(card);
                 break;
             }


### PR DESCRIPTION
## Summary
- improve stat card layout logic so cards are skipped once the container bottom goes past the cutoff

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68682cce69a0832f911395fa29a35262