### PR TITLE
Fix stat card overflow detection

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -2047,6 +2047,8 @@ export const app = {
 
         const viewport = window.visualViewport ? window.visualViewport.height : window.innerHeight;
         const shiftSection = document.querySelector('.shift-section');
+        const nav = document.querySelector('.navbar');
+        const navHeight = nav ? nav.getBoundingClientRect().height : 0;
 
         for (const s of stats) {
             const card = document.createElement('div');
@@ -2056,8 +2058,11 @@ export const app = {
             card.addEventListener('click', () => this.showStatDetails(s.id));
             container.appendChild(card);
 
-            const cutoff = Math.min(viewport, shiftSection ? shiftSection.getBoundingClientRect().top : viewport);
-            if (card.getBoundingClientRect().bottom > cutoff) {
+            const cutoff = Math.min(
+                viewport - navHeight,
+                shiftSection ? shiftSection.getBoundingClientRect().top - navHeight : viewport - navHeight
+            );
+            if (container.getBoundingClientRect().bottom > cutoff) {
                 container.removeChild(card);
                 break;
             }


### PR DESCRIPTION
## Summary
- improve stat card layout logic so cards are skipped once the container bottom passes the cutoff
- account for a fixed navbar when calculating stat card overflow

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68682cce69a0832f911395fa29a35262