### PR TITLE
Fix jsPDF destructuring bug for PDF export

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -4358,7 +4358,7 @@ export const app = {
             }
 
             // Create new PDF instance
-            const { jsPDF } = window.jsPDF;
+            const jsPDF = window.jsPDF;
             const doc = new jsPDF();
 
             // Set up document properties


### PR DESCRIPTION
Fix PDF export by correcting the `jsPDF` constructor import.

The previous code attempted to destructure `jsPDF` from `window.jsPDF` (`const { jsPDF} = window.jsPDF;`), but the jsPDF UMD build exposes the constructor directly as `window.jsPDF`, causing a runtime error and preventing PDF generation.