### PR TITLE
Fix jsPDF instantiation for PDF export

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -4352,13 +4352,13 @@ export const app = {
     exportAsPDF(data) {
         try {
             // Check if jsPDF is available
-            if (typeof window.jsPDF === 'undefined') {
+            if (typeof window.jspdf === 'undefined' || typeof window.jspdf.jsPDF === 'undefined') {
                 alert('PDF-biblioteket kunne ikke lastes. Prøv å laste siden på nytt.');
                 return;
             }
 
             // Create new PDF instance
-            const jsPDF = window.jsPDF;
+            const jsPDF = window.jspdf.jsPDF;
             const doc = new jsPDF();
 
             // Set up document properties


### PR DESCRIPTION
Fix PDF export by correcting jsPDF library access path.

The `jsPDF` library (v2.5.1 UMD build) exposes its constructor at `window.jspdf.jsPDF`, but the code was incorrectly attempting to use `window.jsPDF`, leading to "PDF library not loaded" or "not a constructor" errors.