### PR TITLE
Fix PDF export availability check

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -4352,7 +4352,7 @@ export const app = {
     exportAsPDF(data) {
         try {
             // Check if jsPDF is available
-            if (typeof window.jspdf === 'undefined' || typeof window.jspdf.jsPDF === 'undefined') {
+            if (typeof window.jspdf === 'undefined' || !window.jspdf || typeof window.jspdf.jsPDF === 'undefined') {
                 alert('PDF-biblioteket kunne ikke lastes. Prøv å laste siden på nytt.');
                 return;
             }


### PR DESCRIPTION
Fix `TypeError` in PDF export availability check when `window.jspdf` is `null`.

The original check `typeof window.jspdf === 'undefined' || typeof window.jspdf.jsPDF === 'undefined'` would fail if `window.jspdf` was `null` (since `typeof null` is `'object'`), leading to a `TypeError` when attempting to access `.jsPDF` on `null`. The added `!window.jspdf` condition now correctly handles this case.