### PR TITLE
Remove unnecessary setTimeout blocks

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -4903,11 +4903,6 @@ export const app = {
                 } else {
                     customSection.style.display = 'none';
                 }
-                
-                // Adjust modal height after showing/hiding sections
-                setTimeout(() => {
-        
-                }, 50);
             });
         });
         


### PR DESCRIPTION
Remove unused `setTimeout` block to eliminate unnecessary delay.