### PR TITLE
Reset month selection on page load

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -1162,10 +1162,9 @@ export const app = {
     
     changeMonth(month) {
         this.currentMonth = month;
-        this.saveFormState(); // Save when month changes
         this.updateDisplay(true); // Enable animation when switching months
         this.populateDateGrid();
-        this.saveSettingsToSupabase(); // This will also update last_active via saveSettingsToSupabase
+        // Note: Don't save currentMonth to settings - it should always default to current month on page load
     },
     async loadFromSupabase() {
         const { data: { user } } = await window.supa.auth.getUser();
@@ -1397,7 +1396,7 @@ export const app = {
                 if ('wage_level' in existingSettings) settingsData.wage_level = this.currentWageLevel;
                 if ('current_wage_level' in existingSettings) settingsData.current_wage_level = this.currentWageLevel;
                 if ('custom_wage' in existingSettings) settingsData.custom_wage = this.customWage;
-                if ('current_month' in existingSettings) settingsData.current_month = this.currentMonth;
+                // Remove currentMonth from settings - it should always default to current month on page load
                 if ('pause_deduction' in existingSettings) settingsData.pause_deduction = this.pauseDeduction;
                 if ('full_minute_range' in existingSettings) settingsData.full_minute_range = this.fullMinuteRange;
                 if ('direct_time_input' in existingSettings) settingsData.direct_time_input = this.directTimeInput;
@@ -1413,7 +1412,7 @@ export const app = {
                 settingsData.use_preset = this.usePreset;
                 settingsData.wage_level = this.currentWageLevel;
                 settingsData.custom_wage = this.customWage;
-                settingsData.current_month = this.currentMonth;
+                // Remove currentMonth from settings - it should always default to current month on page load
                 settingsData.pause_deduction = this.pauseDeduction;
                 settingsData.full_minute_range = this.fullMinuteRange;
                 settingsData.direct_time_input = this.directTimeInput;
@@ -1458,7 +1457,7 @@ export const app = {
                 this.customWage = data.customWage || 200;
                 this.currentWageLevel = data.currentWageLevel || 1;
                 this.customBonuses = data.customBonuses || {};
-                this.currentMonth = data.currentMonth || new Date().getMonth() + 1; // Default to current month
+                this.currentMonth = new Date().getMonth() + 1; // Always default to current month
                 this.pauseDeduction = data.pauseDeduction !== false;
                 this.fullMinuteRange = data.fullMinuteRange || false;
                 this.directTimeInput = data.directTimeInput || false;
@@ -1486,7 +1485,7 @@ export const app = {
             startMinute: document.getElementById('startMinute')?.value || '',
             endHour: document.getElementById('endHour')?.value || '',
             endMinute: document.getElementById('endMinute')?.value || '',
-            currentMonth: this.currentMonth
+            // Remove currentMonth from form state - it should always default to current month on page load
         };
         
         this.formState = formState;
@@ -1526,24 +1525,7 @@ export const app = {
                     if (endMinute && formState.endMinute) endMinute.value = formState.endMinute;
                 }, 100);
                 
-                // Restore current month if it was changed from default
-                if (formState.currentMonth && formState.currentMonth !== new Date().getMonth() + 1) { // Compare to current month default
-                    this.currentMonth = formState.currentMonth;
-                    // Update the date grid for the restored month
-                    this.populateDateGrid();
-                    // Re-select the date cell after date grid update
-                    if (formState.selectedDate) {
-                        setTimeout(() => {
-                            const dateDay = this.selectedDate.getDate();
-                            const dateCells = document.querySelectorAll('.date-cell');
-                            dateCells.forEach(cell => {
-                                if (cell.textContent == dateDay && !cell.classList.contains('disabled')) {
-                                    cell.classList.add('selected');
-                                }
-                            });
-                        }, 50);
-                    }
-                }
+                // Remove currentMonth restoration - it should always default to current month on page load
                 
                 this.formState = formState;
             }
@@ -1855,7 +1837,7 @@ export const app = {
                 customWage: this.customWage,
                 currentWageLevel: this.currentWageLevel,
                 customBonuses: this.customBonuses,
-                currentMonth: this.currentMonth,
+                // Remove currentMonth from localStorage - it should always default to current month on page load
                 pauseDeduction: this.pauseDeduction,
                 fullMinuteRange: this.fullMinuteRange,
                 directTimeInput: this.directTimeInput,

--- a/month-selection-fix.md
+++ b/month-selection-fix.md
@@ -1,0 +1,105 @@
+# Month Selection Fix
+
+## Problem
+The web page was saving the selected month state to both localStorage and Supabase, causing the app to remember the previously selected month instead of always defaulting to the current month on page load.
+
+## Root Cause
+The `currentMonth` property was being persisted in multiple places:
+1. **localStorage settings** - saved when settings changed
+2. **Supabase settings** - saved when settings changed  
+3. **Form state in localStorage** - saved when form inputs changed
+4. **Restored on page load** - from both localStorage and Supabase
+
+## Changes Made
+
+### 1. Removed currentMonth from `changeMonth()` function
+```javascript
+// Before: Saved form state and settings when month changed
+changeMonth(month) {
+    this.currentMonth = month;
+    this.saveFormState(); // ❌ REMOVED
+    this.updateDisplay(true);
+    this.populateDateGrid();
+    this.saveSettingsToSupabase(); // ❌ REMOVED
+}
+
+// After: Only updates display, doesn't persist
+changeMonth(month) {
+    this.currentMonth = month;
+    this.updateDisplay(true);
+    this.populateDateGrid();
+    // Note: Don't save currentMonth to settings
+}
+```
+
+### 2. Removed currentMonth from Supabase settings
+```javascript
+// Before: Saved currentMonth to database
+if ('current_month' in existingSettings) settingsData.current_month = this.currentMonth;
+settingsData.current_month = this.currentMonth;
+
+// After: Removed both instances
+// Remove currentMonth from settings - it should always default to current month on page load
+```
+
+### 3. Removed currentMonth from localStorage settings
+```javascript
+// Before: Saved currentMonth to localStorage
+const data = {
+    // ... other settings
+    currentMonth: this.currentMonth,
+    // ... more settings
+};
+
+// After: Removed from saved data
+const data = {
+    // ... other settings
+    // Remove currentMonth from localStorage - it should always default to current month on page load
+    // ... more settings
+};
+```
+
+### 4. Always set currentMonth to current month on load
+```javascript
+// Before: Loaded saved currentMonth from localStorage
+this.currentMonth = data.currentMonth || new Date().getMonth() + 1;
+
+// After: Always defaults to current month
+this.currentMonth = new Date().getMonth() + 1; // Always default to current month
+```
+
+### 5. Removed currentMonth from form state
+```javascript
+// Before: Saved currentMonth in form state
+const formState = {
+    // ... other form fields
+    currentMonth: this.currentMonth
+};
+
+// After: Removed from form state
+const formState = {
+    // ... other form fields
+    // Remove currentMonth from form state - it should always default to current month on page load
+};
+```
+
+### 6. Removed currentMonth restoration logic
+```javascript
+// Before: Restored currentMonth from form state
+if (formState.currentMonth && formState.currentMonth !== new Date().getMonth() + 1) {
+    this.currentMonth = formState.currentMonth;
+    // ... update UI logic
+}
+
+// After: Removed restoration logic
+// Remove currentMonth restoration - it should always default to current month on page load
+```
+
+## Result
+Now the web page will:
+- ✅ Always load showing the current month
+- ✅ Allow users to navigate to other months during their session
+- ✅ Reset to the current month on every page refresh/reload
+- ✅ Not remember the previously selected month
+
+The fix ensures that the expected behavior is implemented: the page always defaults to the current month on load, regardless of what month the user was viewing before refreshing the page.


### PR DESCRIPTION
Stop persisting the selected month to ensure the page always defaults to the current month on load.