### PR TITLE
Fix date grid population bug

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -1048,6 +1048,10 @@ export const app = {
     
     populateDateGrid() {
         const dateGrid = document.getElementById('dateGrid');
+        if (!dateGrid) {
+            // dateGrid element doesn't exist (modal not open), so skip population
+            return;
+        }
         const year = this.YEAR;
         const monthIdx = this.currentMonth - 1;
         const firstDay = new Date(year, monthIdx, 1);
@@ -1906,7 +1910,6 @@ export const app = {
         this.updateShiftList();
         this.updateShiftCalendar();
         this.updateNextShiftCard();
-        this.populateDateGrid();
     },
     updateHeader() {
         const monthName = this.MONTHS[this.currentMonth - 1].charAt(0).toUpperCase() + this.MONTHS[this.currentMonth - 1].slice(1);


### PR DESCRIPTION
Fix `TypeError` in `updateDisplay()` by ensuring `populateDateGrid()` only executes when its required DOM element is present.

The previous call to `populateDateGrid()` from `updateDisplay()` caused a `TypeError` when the 'Add Shift' modal was closed, as the `#dateGrid` element was not available. This change also eliminates redundant calls and prevents unintended clearing of selected date states.