### PR TITLE
Fix shift updates when modal is open

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -1910,6 +1910,7 @@ export const app = {
         this.updateShiftList();
         this.updateShiftCalendar();
         this.updateNextShiftCard();
+        this.populateDateGrid();
     },
     updateHeader() {
         const monthName = this.MONTHS[this.currentMonth - 1].charAt(0).toUpperCase() + this.MONTHS[this.currentMonth - 1].slice(1);


### PR DESCRIPTION
Restore `populateDateGrid()` call to `updateDisplay()` to fix stale shift indicators in the modal.

Previously, removing this call prevented the date grid from updating when shifts were modified, causing stale blue dot indicators until the modal was reopened. The `populateDateGrid()` function safely handles cases where the modal is not open.