### PR TITLE
Fix CSS selector for date cell highlighting

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -834,7 +834,7 @@ export const app = {
         
         // Clear any previously selected dates
         this.selectedDates = [];
-        const dateButtons = document.querySelectorAll('#dateGrid .date-btn');
+        const dateButtons = document.querySelectorAll('#dateGrid .date-cell');
         dateButtons.forEach(btn => btn.classList.remove('selected'));
         
         // Update the selected dates info


### PR DESCRIPTION
Fix incorrect CSS selector in `openAddShiftModal` to correctly clear visual date selection.