### PR TITLE
Vis progressbar over måloppnåelse

### DIFF
--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -30,7 +30,6 @@
   transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1), background 0.3s ease;
   position: relative;
   overflow: hidden;
-  max-width: 100%;
   /* Ensure initial state is 0% width for smooth animation */
   width: 0%;
   will-change: width;
@@ -104,6 +103,40 @@
     transparent 0%,
     rgba(16,120,59,0.08) 100%
   );
+}
+
+/* Overachievement styling - when goal is exceeded */
+.progress-fill.overachievement {
+  background: linear-gradient(135deg,
+    var(--success) 0%,
+    var(--accent) 50%,
+    var(--primary) 100%
+  );
+  box-shadow: 0 0 20px rgba(16, 185, 129, 0.3);
+}
+
+.progress-fill.overachievement::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    rgba(255,255,255,0.1) 50%,
+    transparent 100%
+  );
+  animation: overachievementShimmer 2s infinite;
+}
+
+@keyframes overachievementShimmer {
+  0%, 100% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(100%);
+  }
 }
 
 @keyframes goalCelebrate {

--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -32,7 +32,7 @@ if (origOpenSettings) {
 window.pendingConfetti = false;
 // Oppdater fremdriftslinje for månedlig inntektsmål
 function updateProgressBar(current, goal, shouldAnimate = false) {
-    const percent = ((current / goal) * 100).toFixed(1);
+    const percent = (goal > 0 ? (current / goal) * 100 : 0).toFixed(1);
     const fill = document.querySelector('.progress-fill');
     const label = document.querySelector('.progress-label');
     if (!fill || !label) return;

--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -32,7 +32,7 @@ if (origOpenSettings) {
 window.pendingConfetti = false;
 // Oppdater fremdriftslinje for månedlig inntektsmål
 function updateProgressBar(current, goal, shouldAnimate = false) {
-    const percent = Math.min((current / goal) * 100, 100).toFixed(1);
+    const percent = ((current / goal) * 100).toFixed(1);
     const fill = document.querySelector('.progress-fill');
     const label = document.querySelector('.progress-label');
     if (!fill || !label) return;
@@ -41,6 +41,9 @@ function updateProgressBar(current, goal, shouldAnimate = false) {
     if (shouldAnimate && fill.dataset.animating === 'true') {
         return;
     }
+    
+    // Calculate display width (capped at 100% for visual display)
+    const displayWidth = Math.min(parseFloat(percent), 100);
     
     // Set initial width to 0 if animating
     if (shouldAnimate) {
@@ -62,7 +65,7 @@ function updateProgressBar(current, goal, shouldAnimate = false) {
             fill.offsetHeight;
             
             // Start the width animation
-            fill.style.width = percent + '%';
+            fill.style.width = displayWidth + '%';
             
             // Set a flag to prevent immediate updates from overriding the animation
             fill.dataset.animating = 'true';
@@ -79,7 +82,7 @@ function updateProgressBar(current, goal, shouldAnimate = false) {
         if (fill.dataset.animating !== 'true') {
             // Remove animation for immediate updates
             fill.style.transition = 'none';
-            fill.style.width = percent + '%';
+            fill.style.width = displayWidth + '%';
         }
     }
     
@@ -89,6 +92,12 @@ function updateProgressBar(current, goal, shouldAnimate = false) {
     
     if (percent >= 100) {
         fill.classList.add('full');
+        // Add overachievement styling for values above 100%
+        if (percent > 100) {
+            fill.classList.add('overachievement');
+        } else {
+            fill.classList.remove('overachievement');
+        }
         // Only trigger confetti when appropriate
         if (shouldAnimate) {
             // Wait for progress animation to complete before showing confetti
@@ -101,6 +110,7 @@ function updateProgressBar(current, goal, shouldAnimate = false) {
         }
     } else {
         fill.classList.remove('full');
+        fill.classList.remove('overachievement');
     }
 }
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable progress bar to show values above 100% and add visual overachievement effects to improve motivation.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The progress bar label now displays the exact percentage, even if over 100%, while the visual bar itself caps at 100% width. When exceeding 100%, a special animated style is applied to highlight overachievement.