### PR TITLE
Adjust progress bar glow alignment

### DIFF
--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -123,8 +123,8 @@
   animation: none;
 }
 
-/* Add glowing border to indicate overachievement */
-.progress-fill.overachievement::after {
+/* Add glowing border to indicate overachievement - positioned on the progress card */
+.progress-card.overachievement::after {
   content: '';
   position: absolute;
   top: -2px;
@@ -138,6 +138,8 @@
               0 0 32px rgba(16, 185, 129, 0.4),
               inset 0 0 16px rgba(16, 185, 129, 0.2);
   animation: glowPulse 2s ease-in-out infinite alternate;
+  pointer-events: none;
+  z-index: 1;
 }
 
 @keyframes glowPulse {

--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -93,10 +93,11 @@ function updateProgressBar(current, goal, shouldAnimate = false) {
     if (percent >= 100) {
         fill.classList.add('full');
         // Add overachievement styling for values above 100%
+        const progressCard = fill.closest('.progress-card');
         if (percent > 100) {
-            fill.classList.add('overachievement');
+            if (progressCard) progressCard.classList.add('overachievement');
         } else {
-            fill.classList.remove('overachievement');
+            if (progressCard) progressCard.classList.remove('overachievement');
         }
         // Only trigger confetti when appropriate
         if (shouldAnimate) {
@@ -110,7 +111,8 @@ function updateProgressBar(current, goal, shouldAnimate = false) {
         }
     } else {
         fill.classList.remove('full');
-        fill.classList.remove('overachievement');
+        const progressCard = fill.closest('.progress-card');
+        if (progressCard) progressCard.classList.remove('overachievement');
     }
 }
 


### PR DESCRIPTION
Reposition glow effect on progress bar to correctly display when over 100%.

The glow effect was incorrectly positioned when progress exceeded 100%, appearing on the left side of the bar. This PR fixes it by applying the `overachievement` class and the glow styling to the fixed-width `.progress-card` container instead of the `.progress-fill` element, ensuring the glow correctly surrounds the visible progress bar area.