### PR TITLE
Fix confetti trigger timing

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -146,8 +146,8 @@ function updateProgressBar(current, goal, shouldAnimate = false) {
         // Re-enable transition for future animations
         fill.style.transition = 'width 0.8s cubic-bezier(0.4, 0, 0.2, 1)';
         
-        // Only trigger confetti for immediate updates if goal is reached
-        if (percent >= 100) {
+        // Only trigger confetti for immediate updates if goal is reached AND initial animation is complete
+        if (percent >= 100 && typeof app !== 'undefined' && app.initialAnimationComplete) {
             triggerConfettiIfVisible();
         }
     }


### PR DESCRIPTION
Prevent confetti from triggering twice on page load by ensuring it only sprinkles after the progress bar animation completes.

The confetti was triggered both on initial page load (due to an immediate progress bar update) and again after the progress bar animation completed. This change ensures confetti only triggers once, either after the animation or on subsequent immediate updates *after* the initial animation has finished.