### PR TITLE
Open add shift modal on date tap

### DIFF
--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -2210,6 +2210,38 @@ input:checked + .slider:before {
   box-shadow: 0 8px 20px var(--shadow-blue);
 }
 
+.calendar-cell.empty-date {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: all 0.3s var(--ease-default);
+  position: relative;
+}
+
+.calendar-cell.empty-date:hover {
+  background: var(--bg-secondary);
+  border: 1px solid var(--accent);
+  transform: scale(1.02);
+  box-shadow: 0 4px 12px var(--shadow-blue);
+}
+
+.calendar-cell.empty-date:hover::after {
+  content: '+';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 20px;
+  color: var(--accent);
+  font-weight: 600;
+  opacity: 0.7;
+  z-index: 1;
+}
+
+.calendar-cell.empty-date:hover .calendar-day-number {
+  opacity: 0.6;
+}
+
 .calendar-day-number {
   font-weight: 600;
   color: var(--text-primary);

--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -2633,6 +2633,16 @@ export const app = {
                             this.showShiftDetails(shiftsForDay[0].id);
                         }
                     };
+                } else {
+                    // Add click handler for empty cells in current month
+                    if (cellDate.getMonth() === monthIdx) {
+                        cell.classList.add('empty-date');
+                        cell.style.cursor = 'pointer';
+                        cell.onclick = (e) => {
+                            e.stopPropagation();
+                            this.openAddShiftModalWithDate(cellDate);
+                        };
+                    }
                 }
 
                 cell.appendChild(content);
@@ -5322,6 +5332,37 @@ export const app = {
         };
 
         reader.readAsText(file);
+    },
+
+    // New function to open add shift modal with pre-selected date
+    openAddShiftModalWithDate(date) {
+        // First open the modal normally
+        this.openAddShiftModal();
+        
+        // Then pre-select the specific date
+        if (date) {
+            this.selectedDates = [new Date(date)];
+            
+            // Wait for the modal to be populated, then select the date
+            setTimeout(() => {
+                const dateButtons = document.querySelectorAll('#dateGrid .date-cell');
+                dateButtons.forEach(btn => {
+                    btn.classList.remove('selected');
+                    // Check if this button represents our target date
+                    const cellContent = btn.querySelector('.date-cell-content');
+                    if (cellContent) {
+                        const dayNumber = parseInt(cellContent.textContent);
+                        if (dayNumber === date.getDate() && 
+                            !btn.classList.contains('disabled')) {
+                            btn.classList.add('selected');
+                        }
+                    }
+                });
+                
+                // Update the selected dates info
+                this.updateSelectedDatesInfo();
+            }, 50);
+        }
     }
 };
 


### PR DESCRIPTION
Allow opening the add shift modal with a pre-selected date by tapping empty calendar cells in the shift calendar view.