### PR TITLE
Fix inconsistent button spacing in mobile form

### DIFF
--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -3472,11 +3472,6 @@ input:checked + .slider:before {
   .form-actions .btn {
     flex: 1;
     min-width: auto;
-    margin-right: 8px;
-  }
-  
-  .form-actions .btn:last-child {
-    margin-right: 0;
   }
 }
 


### PR DESCRIPTION
Remove redundant `margin-right` from mobile form action buttons to fix inconsistent spacing.

The `.form-actions` flex container used `gap: 12px`, but its child buttons also applied `margin-right: 8px`. This conflict created uneven spacing (20px vs 12px) instead of the consistent 12px intended by `gap`.