### PR TITLE
Fix date grid month display bug

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -792,6 +792,9 @@ export const app = {
         } else if (targetMonth !== null && targetYear !== null) {
             // If we have a target month/year, repopulate the grid
             this.populateDateGrid(targetMonth, targetYear);
+        } else if (targetMonth === null && targetYear === null) {
+            // If no target parameters, always repopulate to show current month
+            this.populateDateGrid(targetMonth, targetYear);
         }
         
         // Show the modal


### PR DESCRIPTION
Always repopulate the date grid in `openAddShiftModal` when opened without parameters to correctly display the current month.