### PR TITLE
Fix FID calculation operator precedence

### DIFF
--- a/kalkulator/js/performance-monitor.js
+++ b/kalkulator/js/performance-monitor.js
@@ -142,7 +142,7 @@ class PerformanceMonitor {
         new PerformanceObserver((list) => {
             const entries = list.getEntries();
             entries.forEach(entry => {
-                log.info('FID:', `${entry.processingStart - entry.startTime.toFixed(2)}ms`);
+                log.info('FID:', `${(entry.processingStart - entry.startTime).toFixed(2)}ms`);
             });
         }).observe({ entryTypes: ['first-input'] });
 


### PR DESCRIPTION
Correct First Input Delay (FID) calculation to resolve operator precedence error.

Previously, `.toFixed(2)` was incorrectly applied to `entry.startTime` before subtraction, converting it to a string and causing a type error.