### PR TITLE
Fix progress bar display issue

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -132,8 +132,8 @@ function updateProgressBar(current, goal, shouldAnimate = false) {
         if (progressCard) progressCard.classList.remove('overachievement');
     }
     
-    // Add active class when nearing goal completion
-    if (percent >= 80) {
+    // Add active class to show color when there's any progress
+    if (percent > 0) {
         fill.classList.add('active');
     } else {
         fill.classList.remove('active');


### PR DESCRIPTION
Change progress bar coloring logic to display color for any progress, fixing a bug where it only showed color above 80%.

Previously, the progress bar's fill color (via the 'active' class) was only applied when the progress percentage reached 80% or more. This meant that for months with less than 80% progress, the bar appeared uncolored, even if there was some progress.