### PR TITLE
Change text color for lørdag and søndag

### DIFF
--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -1654,7 +1654,7 @@ input:checked + .slider:before {
 }
 
 .shift-type.sunday {
-  background: var(--accent3);
+  background: var(--accent2);
   color: var(--bg-primary);
 }
 


### PR DESCRIPTION
Align 'søndag' shift text background color with its border.

Previously, the 'søndag' shift box had a `var(--accent2)` left border but its text background was `var(--accent3)`, leading to a color mismatch. This change ensures consistency, similar to how 'lørdag' shifts are styled.