### PR TITLE
Fix modal footer positioning issue

### DIFF
--- a/kalkulator/app.html
+++ b/kalkulator/app.html
@@ -441,7 +441,6 @@
                       <small class="form-hint">Importer vaktdata fra CSV eller JSON-fil</small>
                   </div>
               </div>
-          </div>
           
           <!-- Fixed bottom close button for settings modal -->
           <div class="modal-fixed-footer">
@@ -452,6 +451,7 @@
                   </svg>
                   Lukk
               </button>
+          </div>
           </div>
       </div>
   </div>
@@ -620,7 +620,6 @@
                       </div>
                   </form>
               </div>
-          </div>
           
           <!-- Fixed bottom close button for add shift modal -->
           <div class="modal-fixed-footer">
@@ -631,6 +630,7 @@
                   </svg>
                   Lukk
               </button>
+          </div>
           </div>
       </div>
 


### PR DESCRIPTION
Move modal footers inside `modal-content` divs to correctly position them relative to the modal.

The `modal-fixed-footer` elements were previously outside their respective `modal-content` divs, causing them to be positioned relative to the viewport instead of the modal's content area.