### PR TITLE
Fix wage calculation for fixed pause time

### DIFF
--- a/kalkulator/app.html
+++ b/kalkulator/app.html
@@ -259,8 +259,8 @@
                               </div>
                               <div class="form-row">
                                   <label class="pause-sublabel">Alternativ:</label>
-                                  <input type="time" class="form-control pause-time-input" id="fixedPauseTime" placeholder="f.eks. 12:00" onchange="app.updateFixedPauseSettings()">
-                                  <small class="form-hint">Eller velg fast tidspunkt på dagen</small>
+                                  <input type="time" class="form-control pause-time-input" id="fixedPauseTime" placeholder="f.eks. 00:30" onchange="app.updateFixedPauseSettings()">
+                                  <small class="form-hint">Eller skriv pausetid direkte (f.eks. 00:30 for 30 min)</small>
                               </div>
                           </div>
                           

--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -3643,18 +3643,24 @@ export const app = {
                 break;
             case 'fixed':
                 // Deduct fixed pause time from all shifts
+                let fixedPauseTotal = 0;
+                
                 if (this.fixedPauseTime) {
-                    // If a specific time is set, don't deduct anything (time-based pause)
-                    // The time represents when the pause was taken, not a deduction
-                } else {
-                    // Deduct the fixed hours and minutes
-                    const fixedPauseTotal = (this.fixedPauseHours * 60) + this.fixedPauseMinutes;
-                    if (fixedPauseTotal > 0) {
-                        pauseMinutes = fixedPauseTotal;
-                        paidHours -= fixedPauseTotal / 60;
-                        adjustedEndMinutes -= fixedPauseTotal;
-                        pauseDeducted = true;
+                    // Parse time input (e.g., "00:30") as duration in minutes
+                    const [hours, minutes] = this.fixedPauseTime.split(':').map(Number);
+                    if (!isNaN(hours) && !isNaN(minutes)) {
+                        fixedPauseTotal = (hours * 60) + minutes;
                     }
+                } else {
+                    // Use the fixed hours and minutes from dropdowns
+                    fixedPauseTotal = (this.fixedPauseHours * 60) + this.fixedPauseMinutes;
+                }
+                
+                if (fixedPauseTotal > 0) {
+                    pauseMinutes = fixedPauseTotal;
+                    paidHours -= fixedPauseTotal / 60;
+                    adjustedEndMinutes -= fixedPauseTotal;
+                    pauseDeducted = true;
                 }
                 break;
             case 'individual':


### PR DESCRIPTION
```
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable `fixedPauseTime` to deduct pause duration from wage calculations and clarify its UI purpose.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the `fixedPauseTime` input was treated as a specific time of day when a pause occurred, not as a duration to be deducted. This contradicted the UI's presentation of it as an alternative to fixed hour/minute deductions, making it effectively non-functional for its implied purpose.
```