### PR TITLE
Adjust add shift modal bottom bar

### DIFF
--- a/add-shift-modal-positioning-fix.md
+++ b/add-shift-modal-positioning-fix.md
@@ -1,0 +1,78 @@
+# Add Shift Modal Positioning Fix
+
+## Issue
+The add shift modal's bottom bar was extending beyond the viewport when the navigation bar was taken into consideration. The modal content was not properly centered with the navigation header in mind.
+
+## Root Cause
+The modal was positioned using full viewport height without accounting for the navigation bar (`.header`) which has a minimum height of 80px. This caused:
+- Modal content to extend below the visible area
+- Poor centering that didn't consider the header space
+- Bottom buttons/footer becoming inaccessible on smaller screens
+
+## Solution Applied
+
+### 1. Desktop Modal Positioning
+- **File**: `/workspace/kalkulator/css/style.css`
+- **Changes**:
+  - Added `max-height: calc(100vh - 100px)` to account for header (80px) + padding
+  - Added `margin-top: 50px` to center modal below header
+  - Updated modal body with `max-height: calc(100vh - 180px)` to prevent overflow
+  - Added specific modal active positioning with `align-items: flex-start` and `padding-top: 50px`
+
+### 2. Mobile Modal Positioning  
+- **Changes**:
+  - Updated mobile modal height to `calc(100vh - 80px)` to account for navigation header
+  - Added `margin-top: 80px` to position modal below navigation header
+  - Updated modal body height to `calc(100vh - 200px)` (nav header 80px + form actions 120px)
+  - Reset desktop padding on mobile with `padding-top: 0`
+
+### 3. Desktop Specific Sizing
+- **Changes**:
+  - Updated desktop modal max-height to `calc(90vh - 80px)` 
+  - Added `margin-top: 10vh` for proper centering in available space
+
+## Technical Details
+
+### Key CSS Changes:
+
+```css
+/* Desktop positioning */
+#addShiftModal .modal-content {
+  max-height: calc(100vh - 100px);
+  margin-top: 50px;
+}
+
+#addShiftModal .modal-body {
+  max-height: calc(100vh - 180px);
+}
+
+#addShiftModal.active {
+  align-items: flex-start;
+  padding-top: 50px;
+}
+
+/* Mobile positioning */
+@media (max-width: 768px) {
+  #addShiftModal .modal-content {
+    height: calc(100vh - 80px);
+    margin-top: 80px;
+  }
+  
+  #addShiftModal .modal-body {
+    height: calc(100vh - 200px);
+  }
+  
+  #addShiftModal.active {
+    padding-top: 0;
+  }
+}
+```
+
+## Result
+- Modal bottom bar now stays within viewport bounds
+- Content is properly centered with navigation bar considered
+- Consistent positioning across different screen sizes
+- Better user experience with all buttons remaining accessible
+
+## Files Modified
+- `/workspace/kalkulator/css/style.css` - Modal positioning and sizing updates

--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -1005,6 +1005,20 @@ input[type="time"].form-control[value=""]:focus {
   backdrop-filter: blur(5px);
 }
 
+/* Special positioning for add shift modal to account for navigation header */
+#addShiftModal.active {
+  align-items: flex-start;
+  padding-top: 50px; /* Position below header with some spacing */
+}
+
+/* Mobile override for add shift modal positioning */
+@media (max-width: 768px) {
+  #addShiftModal.active {
+    padding-top: 0; /* Reset desktop padding */
+    align-items: flex-start; /* Keep at top since modal content already has margin-top: 80px */
+  }
+}
+
 .modal-content {
   background: linear-gradient(135deg, var(--bg-secondary), var(--bg-tertiary));
   margin: 0;
@@ -3259,6 +3273,9 @@ input:checked + .slider:before {
   max-width: 600px;
   position: relative;
   overflow: hidden;
+  /* Ensure modal doesn't extend below viewport when accounting for header */
+  max-height: calc(100vh - 100px); /* Account for header (80px) + some padding */
+  margin-top: 50px; /* Center with header taken into account */
 }
 
 #addShiftModal .date-grid {
@@ -3270,6 +3287,8 @@ input:checked + .slider:before {
   padding-top: 20px;
   padding-bottom: 80px; /* Add space for fixed footer */
   overflow-y: auto;
+  /* Ensure modal body doesn't overflow when considering header */
+  max-height: calc(100vh - 180px); /* Account for header + modal top margin + footer */
 }
 
 /* Add shift modal close button in form actions */
@@ -3401,25 +3420,26 @@ input:checked + .slider:before {
   #addShiftModal .modal-content,
   #editShiftModal .modal-content {
     width: 100vw;
-    height: 100vh;
+    height: calc(100vh - 80px); /* Account for navigation header */
     max-width: none;
-    max-height: none;
+    max-height: calc(100vh - 80px);
     border-radius: 0;
     margin: 0;
+    margin-top: 80px; /* Position below the navigation header */
     position: relative; /* Ensure relative positioning for absolute close button */
   }
   
   #addShiftModal .modal-body,
   #editShiftModal .modal-body {
     padding: 20px;
-    height: calc(100vh - 120px); /* Account for header and form actions */
+    height: calc(100vh - 200px); /* Account for nav header (80px) + form actions (120px) */
     overflow-y: auto;
   }
   
   /* Override for add shift modal body padding */
   #addShiftModal .modal-body {
     padding: 20px 20px 20px 20px;
-    height: calc(100vh - 120px); /* Account for header and form actions */
+    height: calc(100vh - 200px); /* Account for nav header (80px) + form actions (120px) */
   }
 }
 
@@ -3429,7 +3449,8 @@ input:checked + .slider:before {
     max-width: 600px;
     width: 90vw;
     height: auto;
-    max-height: 90vh;
+    max-height: calc(90vh - 80px); /* Account for navigation header */
+    margin-top: 10vh; /* Center in available space below header */
   }
 }
 


### PR DESCRIPTION
Adjust add shift modal positioning to keep its bottom bar within the viewport and center content, accounting for the navigation bar.

The modal previously extended beyond the viewport, making bottom elements inaccessible, because it didn't account for the fixed navigation bar's height.