### PR TITLE
Center modal buttons with padding

### DIFF
--- a/kalkulator/app.html
+++ b/kalkulator/app.html
@@ -624,21 +624,23 @@
               </div>
           
           <!-- Fixed bottom buttons for add shift modal -->
-          <div class="modal-fixed-footer" style="justify-content: space-between;">
-              <button type="button" class="btn btn-primary" onclick="app.addShift()">
-                  <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                      <circle cx="12" cy="12" r="10"></circle>
-                      <line x1="12" y1="8" x2="12" y2="16"></line>
-                      <line x1="8" y1="12" x2="16" y2="12"></line>
-                  </svg>
-                  Legg til vakt
-              </button>
-              <button type="button" class="btn btn-secondary modal-close-bottom" onclick="app.closeAddShiftModal()">
-                  <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                      <line x1="18" y1="6" x2="6" y2="18"></line>
-                      <line x1="6" y1="6" x2="18" y2="18"></line>
-                  </svg>
-              </button>
+          <div class="modal-fixed-footer">
+              <div class="modal-button-group">
+                  <button type="button" class="btn btn-primary" onclick="app.addShift()">
+                      <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                          <circle cx="12" cy="12" r="10"></circle>
+                          <line x1="12" y1="8" x2="12" y2="16"></line>
+                          <line x1="8" y1="12" x2="16" y2="12"></line>
+                      </svg>
+                      Legg til vakt
+                  </button>
+                  <button type="button" class="btn btn-secondary modal-close-bottom" onclick="app.closeAddShiftModal()">
+                      <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                          <line x1="18" y1="6" x2="6" y2="18"></line>
+                          <line x1="6" y1="6" x2="18" y2="18"></line>
+                      </svg>
+                  </button>
+              </div>
           </div>
           </div>
       </div>

--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -3367,6 +3367,14 @@ input:checked + .slider:before {
   border-radius: 0 0 16px 16px;
 }
 
+/* Modal button group for centered buttons */
+.modal-button-group {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  align-items: center;
+}
+
 /* Modal footer with buttons on both sides */
 .modal-fixed-footer[style*="space-between"] {
   justify-content: space-between;

--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -3380,9 +3380,9 @@ input:checked + .slider:before {
   justify-content: space-between;
 }
 
-/* Close button positioning - 16px from right edge */
+/* Close button positioning - removed negative margin for centered layout */
 .modal-fixed-footer .modal-close-bottom {
-  margin-right: -8px; /* 16px from edge minus 8px existing padding */
+  /* Negative margin removed to work with centered modal-button-group */
 }
 
 /* Bottom actions section for settings modal - legacy (can be removed if not used elsewhere) */


### PR DESCRIPTION
Center buttons in the add shift modal footer with 16px spacing to prevent them from appearing under screen edges.