### PR TITLE
Fix text shadow on transparent gradient text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -455,6 +455,11 @@ html {
     font-weight: 800;
     line-height: 1.1;
     letter-spacing: -0.02em;
+    background: var(--gradient-primary);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    filter: drop-shadow(0 0 20px rgba(99, 102, 241, 0.5));
 }
 
 .hero-subtitle {


### PR DESCRIPTION
Implement gradient text and a visible glow effect for `.hero-name` by using `filter: drop-shadow()`.

The original bug report stated that `.hero-name` had `text-shadow` and transparent text, but `text-shadow` was not rendering. Investigation revealed that `.hero-name` did not have these styles. This PR adds the intended gradient text fill and uses `filter: drop-shadow()` to achieve a compatible glow effect, as `text-shadow` does not render on transparent text.