### PR TITLE
Fix countdown timer line wrap on shift cards

### DIFF
--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -4185,6 +4185,7 @@ body.compact-view .shift-section .floating-action-bar-backdrop {
   /* Keep countdown timer visible but hide seconds */
   .next-shift-card .shift-countdown-timer {
     display: inline !important; /* Keep countdown timer visible */
+    white-space: nowrap; /* Prevent line breaks */
     /* Remove font-size reduction - keep same size as other text */
   }
   
@@ -4246,6 +4247,12 @@ body.compact-view .shift-section .floating-action-bar-backdrop {
 
 .next-shift-card .countdown-no-parens {
   display: none; /* Hide non-parentheses version */
+}
+
+/* Prevent countdown timer from wrapping to new line */
+.next-shift-card .shift-countdown-timer {
+  white-space: nowrap; /* Prevent line breaks */
+  display: inline-block; /* Keep it inline but prevent wrapping */
 }
 
 


### PR DESCRIPTION
Prevent the next shift card's countdown timer from wrapping to a new line, especially when seconds change from single to double digits.

The countdown would incorrectly wrap on devices like iPhone Pro Max when the width of the seconds changed (e.g., from '9s' to '10s'), despite sufficient space. This fix ensures it stays on a single line, as overflow is handled by the existing narrow screen mode.