### PR TITLE
Fix modal height and scrollability on desktop

### DIFF
--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -3507,7 +3507,6 @@ input:checked + .slider:before {
   /* Override for add shift modal body padding */
   #addShiftModal .modal-body {
     padding: 20px 20px 20px 20px;
-    height: calc(100vh - 240px); /* Account for nav header (80px) + margin (80px) + footer space (80px) */
   }
 }
 


### PR DESCRIPTION
Remove conflicting `height` rule for `#addShiftModal .modal-body` to restore `max-height` and scrollability.

The removed `height` rule was overriding an intended `max-height` and `overflow-y: auto` fix, which led to incorrect height calculations and loss of scrollability for the modal after changes to remove top bar assumptions for centering.