### PR TITLE
Fix undefined css variable in calendar hours

### DIFF
--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -1297,7 +1297,7 @@ input[type="time"].form-control[value=""]:focus {
 }
 
 .calendar-hours-total {
-  color: var(--accent-color);
+  color: var(--accent);
   font-weight: 600;
   font-size: 12px;
   text-align: left !important;


### PR DESCRIPTION
Correct CSS variable from `var(--accent-color)` to `var(--accent)` to apply intended color to `.calendar-hours-total`.