### PR TITLE
Fix calendar hours display time range and DOM

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -2679,23 +2679,33 @@ export const app = {
                         const hoursDisplay = document.createElement('div');
                         hoursDisplay.className = 'calendar-hours-display';
                         
-                        // Get the first shift's start and last shift's end time
-                        // Sort shifts by start time to get proper range
-                        const sortedShifts = shiftsForDay.sort((a, b) => {
-                            const aTime = this.timeToMinutes(a.startTime);
-                            const bTime = this.timeToMinutes(b.startTime);
-                            return aTime - bTime;
-                        });
+                        // Find the absolute earliest start time and latest end time across all shifts
+                        let earliestStartMinutes = Infinity;
+                        let latestEndMinutes = -Infinity;
+                        let earliestStartTime = '';
+                        let latestEndTime = '';
                         
-                        const firstShift = sortedShifts[0];
-                        const lastShift = sortedShifts[sortedShifts.length - 1];
+                        shiftsForDay.forEach(shift => {
+                            const startMinutes = this.timeToMinutes(shift.startTime);
+                            const endMinutes = this.timeToMinutes(shift.endTime);
+                            
+                            if (startMinutes < earliestStartMinutes) {
+                                earliestStartMinutes = startMinutes;
+                                earliestStartTime = shift.startTime;
+                            }
+                            
+                            if (endMinutes > latestEndMinutes) {
+                                latestEndMinutes = endMinutes;
+                                latestEndTime = shift.endTime;
+                            }
+                        });
                         
                         const timeRange = document.createElement('div');
                         timeRange.className = 'calendar-total calendar-hours-total';
-                        timeRange.innerHTML = `${this.formatTimeShort(firstShift.startTime)} -<br>${this.formatTimeShort(lastShift.endTime)}`;
+                        timeRange.innerHTML = `${this.formatTimeShort(earliestStartTime)} -<br>${this.formatTimeShort(latestEndTime)}`;
                         
+                        hoursDisplay.appendChild(timeRange);
                         shiftData.appendChild(hoursDisplay);
-                        shiftData.appendChild(timeRange);
                     }
                     
                     content.appendChild(shiftData);


### PR DESCRIPTION
Fix incorrect time range calculation and DOM structure for calendar's hours display.

The previous time range calculation only considered the earliest start time and the end time of the latest-starting shift, which could lead to an incorrect overall range (e.g., 08:00-16:00 and 12:00-14:00 shifts incorrectly showed 08:00-14:00). This PR now correctly finds the absolute earliest start and latest end time across all shifts. Additionally, the `timeRange` element is now correctly nested within `hoursDisplay` instead of being a sibling.