### PR TITLE
Analyze paused shift handling in current shift

### DIFF
--- a/database-pause-migration.sql
+++ b/database-pause-migration.sql
@@ -1,0 +1,25 @@
+-- SQL Migration: Legg til pausefunksjonalitet i shifts tabellen
+-- Kjør disse kommandoene i din Supabase SQL Editor
+
+-- 1. Legg til pause_start_hours kolonne
+-- Lagrer når pausen starter som timer etter vaktstart (f.eks. 2.5 = 2,5 timer etter vaktstart)
+ALTER TABLE shifts 
+ADD COLUMN pause_start_hours DECIMAL(4,2) DEFAULT NULL;
+
+-- 2. Legg til pause_duration_hours kolonne  
+-- Lagrer varighet av pause i timer (f.eks. 0.5 = 30 minutter)
+ALTER TABLE shifts 
+ADD COLUMN pause_duration_hours DECIMAL(4,2) DEFAULT 0.5;
+
+-- 3. Legg til kommentarer for dokumentasjon
+COMMENT ON COLUMN shifts.pause_start_hours IS 'Timer etter vaktstart når pause begynner (NULL = ingen pause)';
+COMMENT ON COLUMN shifts.pause_duration_hours IS 'Varighet av pause i timer (standard 0.5 = 30 min)';
+
+-- 4. Opprett indeks for bedre performance ved spørringer
+CREATE INDEX idx_shifts_pause_start ON shifts(pause_start_hours) WHERE pause_start_hours IS NOT NULL;
+
+-- 5. Verifiser at kolonnene ble lagt til korrekt
+SELECT column_name, data_type, is_nullable, column_default 
+FROM information_schema.columns 
+WHERE table_name = 'shifts' 
+AND column_name IN ('pause_start_hours', 'pause_duration_hours');

--- a/pause-implementasjon-plan.md
+++ b/pause-implementasjon-plan.md
@@ -1,0 +1,263 @@
+# Implementasjonsplan: Pausefunksjonalitet
+
+## Database Migration
+SQL-kommandoer er klar i `database-pause-migration.sql` - kjør disse i Supabase SQL Editor.
+
+## 1. Innstillinger - Standard Pausetid
+
+### A) Legg til i app.js konstanter:
+```javascript
+DEFAULT_PAUSE_START_HOURS: 2.5,    // Standard pause starter etter 2,5 timer
+DEFAULT_PAUSE_DURATION: 0.5,       // Standard pause er 30 minutter
+```
+
+### B) Legg til i brukerinnstillinger:
+```javascript
+// I appLogic.js
+pauseStartHours: 2.5,    // Timer etter vaktstart
+pauseDuration: 0.5,      // Pause-varighet i timer
+```
+
+### C) UI i settings modal (app.html):
+```html
+<div class="form-group">
+    <label>Standard pausetid</label>
+    <div class="form-group-inline">
+        <div>
+            <label>Pause starter etter</label>
+            <select id="pauseStartHours">
+                <option value="1.5">1,5 timer</option>
+                <option value="2.0">2 timer</option>
+                <option value="2.5" selected>2,5 timer</option>
+                <option value="3.0">3 timer</option>
+                <option value="4.0">4 timer</option>
+            </select>
+        </div>
+        <div>
+            <label>Varighet</label>
+            <select id="pauseDuration">
+                <option value="0.25">15 min</option>
+                <option value="0.5" selected>30 min</option>
+                <option value="0.75">45 min</option>
+                <option value="1.0">1 time</option>
+            </select>
+        </div>
+    </div>
+    <small class="form-hint">Standardverdier for nye vakter. Kan justeres per vakt.</small>
+</div>
+```
+
+## 2. Current Shift Card - Pause Badge og Logikk
+
+### A) Modifiser `calculateCurrentShiftEarnings` funksjon:
+```javascript
+calculateCurrentShiftEarnings(shift, now) {
+    const shiftDate = new Date(shift.date);
+    const [startHour, startMinute] = shift.startTime.split(':').map(Number);
+    const shiftStartTime = new Date(shiftDate);
+    shiftStartTime.setHours(startHour, startMinute, 0, 0);
+    
+    // Calculate time worked so far in hours
+    const timeWorked = now - shiftStartTime;
+    let hoursWorked = timeWorked / (1000 * 60 * 60);
+    
+    // Check if currently in pause
+    const pauseStart = shift.pauseStartHours || this.pauseStartHours;
+    const pauseDuration = shift.pauseDuration || this.pauseDuration;
+    const isInPause = hoursWorked >= pauseStart && hoursWorked <= (pauseStart + pauseDuration);
+    
+    // Adjust hours worked if pause has been completed
+    let paidHours = hoursWorked;
+    if (hoursWorked > (pauseStart + pauseDuration)) {
+        paidHours = hoursWorked - pauseDuration;
+    } else if (isInPause) {
+        // During pause - stop at pause start time
+        paidHours = pauseStart;
+    }
+    
+    // Rest of calculation...
+    const wageRate = this.getCurrentWageRate();
+    const baseEarned = paidHours * wageRate;
+    
+    return {
+        totalHours: hoursWorked,
+        paidHours: paidHours,
+        isInPause: isInPause,
+        pauseStart: pauseStart,
+        pauseDuration: pauseDuration,
+        baseEarned: baseEarned,
+        bonusEarned: bonusEarned,
+        totalEarned: baseEarned + bonusEarned
+    };
+}
+```
+
+### B) Legg til pause badge i `displayCurrentShiftCard`:
+```javascript
+displayCurrentShiftCard(currentShift, now) {
+    // ... existing code ...
+    const currentEarnings = this.calculateCurrentShiftEarnings(currentShift, now);
+    
+    // Lag pause badge
+    const pauseBadge = currentEarnings.isInPause ? '<span class="pause-badge">Pause</span>' : '';
+    const seriesBadge = currentShift.seriesId ? '<span class="series-badge">Serie</span>' : '';
+    
+    const html = `
+        <div class="shift-item ${typeClass} active" data-shift-id="${currentShift.id}">
+            <div class="shift-header">
+                ${pauseBadge}
+                ${seriesBadge}
+                <span class="shift-date">${day}. ${this.MONTHS[shiftDate.getMonth()]}</span>
+                <span class="shift-weekday">${this.WEEKDAYS[shiftDate.getDay()]}</span>
+            </div>
+            <!-- rest of HTML -->
+        </div>
+    `;
+}
+```
+
+### C) CSS for pause badge:
+```css
+.pause-badge {
+    background: #ff6b35;
+    color: white;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 600;
+    animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.7; }
+}
+```
+
+## 3. Vaktdetaljer Modal - Pause Justering
+
+### A) Legg til pause-felt i shift details modal:
+```html
+<div class="pause-section">
+    <h4>Pauseinnstillinger</h4>
+    <div class="form-group">
+        <label>Pause starter etter</label>
+        <select id="editPauseStart">
+            <option value="">Ingen pause</option>
+            <option value="1.5">1,5 timer</option>
+            <option value="2.0">2 timer</option>
+            <option value="2.5">2,5 timer</option>
+            <option value="3.0">3 timer</option>
+            <option value="4.0">4 timer</option>
+        </select>
+    </div>
+    <div class="form-group">
+        <label>Pause-varighet</label>
+        <select id="editPauseDuration">
+            <option value="0.25">15 minutter</option>
+            <option value="0.5">30 minutter</option>
+            <option value="0.75">45 minutter</option>
+            <option value="1.0">1 time</option>
+        </select>
+    </div>
+</div>
+```
+
+### B) Oppdater `showShiftDetails` funksjon:
+```javascript
+showShiftDetails(shiftId) {
+    const shift = this.shifts.find(s => s.id === shiftId);
+    
+    // Populate pause fields
+    document.getElementById('editPauseStart').value = shift.pauseStartHours || '';
+    document.getElementById('editPauseDuration').value = shift.pauseDuration || this.pauseDuration;
+    
+    // ... rest of function
+}
+```
+
+## 4. Database Operasjoner
+
+### A) Oppdater `addShift` funksjon:
+```javascript
+// I Supabase insert
+const shiftData = {
+    user_id: user.id,
+    shift_date: finalDateStr,
+    start_time: newShift.startTime,
+    end_time: newShift.endTime,
+    shift_type: newShift.type,
+    series_id: seriesId,
+    pause_start_hours: this.pauseStartHours,  // Standard verdi
+    pause_duration_hours: this.pauseDuration  // Standard verdi
+};
+```
+
+### B) Oppdater `updateShift` funksjon:
+```javascript
+const updateData = {
+    shift_date: dateStr,
+    start_time: startTime,
+    end_time: endTime,
+    shift_type: type,
+    pause_start_hours: document.getElementById('editPauseStart').value || null,
+    pause_duration_hours: parseFloat(document.getElementById('editPauseDuration').value)
+};
+```
+
+### C) Oppdater `loadUserShifts` mapping:
+```javascript
+this.userShifts = data.map(s => ({
+    id: s.id,
+    date: new Date(s.shift_date + 'T00:00:00.000Z'),
+    startTime: s.start_time,
+    endTime: s.end_time,
+    type: s.shift_type,
+    seriesId: s.series_id || null,
+    pauseStartHours: s.pause_start_hours,
+    pauseDuration: s.pause_duration_hours || 0.5
+}));
+```
+
+## 5. Endelig `calculateHours` oppdatering
+
+Oppdater eksisterende `calculateHours` funksjon til å bruke lagret pause-data:
+
+```javascript
+calculateHours(shift) {
+    // ... existing code ...
+    
+    let paidHours = durationHours;
+    let adjustedEndMinutes = endMinutes;
+    
+    // Use stored pause data instead of fixed deduction
+    if (shift.pauseStartHours && durationHours > shift.pauseStartHours) {
+        const pauseDuration = shift.pauseDuration || 0.5;
+        if (durationHours >= (shift.pauseStartHours + pauseDuration)) {
+            paidHours -= pauseDuration;
+            adjustedEndMinutes -= pauseDuration * 60;
+        }
+    }
+    
+    // ... rest of function
+}
+```
+
+## Testing Sjekkliste
+
+- [ ] Database migration kjørt
+- [ ] Standard pauseinnstillinger fungerer
+- [ ] Pause badge vises i current shift card
+- [ ] Lønnsøkning stopper under pause
+- [ ] Pause kan justeres fra vaktdetaljer
+- [ ] Pause-data lagres og hentes fra database
+- [ ] Eksisterende vakter fungerer (bakoverkompatibilitet)
+- [ ] Endelig lønnsberegning inkluderer pause
+
+## Fordeler med denne løsningen
+
+✅ **Fleksibel**: Pause kan være forskjellig for hver vakt  
+✅ **Transparent**: Brukeren ser når de er i pause  
+✅ **Konsistent**: Samme logikk i live-visning og endelig beregning  
+✅ **Brukervennlig**: Intuitive standardverdier som kan justeres  
+✅ **Bakoverkompatibel**: Eksisterende vakter påvirkes ikke

--- a/pausetrekk-analyse-current-shift-kort.md
+++ b/pausetrekk-analyse-current-shift-kort.md
@@ -1,0 +1,166 @@
+# Analyse: Pausetrekk i Current Shift Kortet
+
+## Problemstilling
+Hvordan tas pausetrekk med i betraktning (eller ignoreres fullstendig) i det aktive vaktkortet som vises under pågående vakter?
+
+## Hovedfunn
+
+### ⚠️ **KRITISK: Pausetrekk ignoreres i live-beregninger**
+
+Det aktive vaktkortet (current shift card) **ignorerer fullstendig pausetrekk** under pågående vakter, selv når vakten er over 5,5 timer.
+
+## Detaljert Analyse
+
+### 1. Pausetrekk-systemet i applikasjonen
+
+#### Konstanter og innstillinger:
+```javascript
+PAUSE_THRESHOLD: 5.5,     // Timer som utløser pausetrekk
+PAUSE_DEDUCTION: 0.5,     // Antall timer som trekkes fra (30 minutter)
+pauseDeduction: true,     // Brukerinnstilling (kan skrus av/på)
+```
+
+#### Brukergrensesnitt:
+- Innstilling i settings: "Pausetrekk" toggle
+- Beskrivelse: "Trekk fra betalt pause for vakter over 5,5 timer"
+- Standard: **Aktivert** (`checked`)
+
+### 2. Hvor pausetrekk BLIR anvendt
+
+#### A) Final vaktberegning (`calculateHours` funksjon):
+```javascript
+// Apply pause deduction if enabled
+if (this.pauseDeduction && durationHours > this.PAUSE_THRESHOLD) {
+    paidHours -= this.PAUSE_DEDUCTION;
+    adjustedEndMinutes -= this.PAUSE_DEDUCTION * 60;
+}
+```
+
+**Anvendes i:**
+- Vaktliste (historiske vakter)
+- Statistikk og totaler
+- Endelig lønnsberegning
+
+### 3. Hvor pausetrekk IKKE blir anvendt
+
+#### A) Live-beregning i current shift card (`calculateCurrentShiftEarnings`):
+```javascript
+calculateCurrentShiftEarnings(shift, now) {
+    // Calculate time worked so far in hours
+    const timeWorked = now - shiftStartTime;
+    const hoursWorked = timeWorked / (1000 * 60 * 60);
+    
+    // Calculate base earnings so far
+    const baseEarned = hoursWorked * wageRate;
+    
+    // ❌ INGEN PAUSETREKK HER!
+    
+    return {
+        totalHours: hoursWorked,      // Rå timer uten pausetrekk
+        baseEarned: baseEarned,       // Grunnlønn uten pausetrekk
+        bonusEarned: bonusEarned,     // Tillegg beregnet på full tid
+        totalEarned: baseEarned + bonusEarned  // Total uten pausetrekk
+    };
+}
+```
+
+## Konsekvenser av denne implementasjonen
+
+### 1. **Brukerforvirring**
+- **Under vakten**: Bruker ser f.eks. 1200 kr for 6-timers vakt
+- **Etter vakten**: Samme vakt viser 1120 kr (80 kr mindre pga. pausetrekk)
+- **Inkonsistens**: Forskjellige beløp for samme vakt
+
+### 2. **Upresise forventninger**
+- Brukere tror de tjener mer enn de faktisk gjør
+- Pausetrekk kommer som en "negativ overraskelse"
+- Manglende transparens i lønnssystemet
+
+### 3. **Tidsforskjell i beregninger**
+- **Live**: Baselønn oppdateres sekund-for-sekund (uten pausetrekk)
+- **Live**: Tillegg oppdateres sekund-for-sekund med `calculateBonusWithSeconds`
+- **Final**: Minutt-basert beregning med pausetrekk
+
+## Løsningsforslag
+
+### Alternativ 1: **Implementer pausetrekk i live-beregning** ⭐ (ANBEFALT)
+
+Modifiser `calculateCurrentShiftEarnings` til å inkludere pausetrekk:
+
+```javascript
+calculateCurrentShiftEarnings(shift, now) {
+    const shiftDate = new Date(shift.date);
+    const [startHour, startMinute] = shift.startTime.split(':').map(Number);
+    const shiftStartTime = new Date(shiftDate);
+    shiftStartTime.setHours(startHour, startMinute, 0, 0);
+    
+    // Calculate time worked so far in hours
+    const timeWorked = now - shiftStartTime;
+    let hoursWorked = timeWorked / (1000 * 60 * 60);
+    
+    // Apply pause deduction if enabled and threshold is met
+    let paidHours = hoursWorked;
+    if (this.pauseDeduction && hoursWorked > this.PAUSE_THRESHOLD) {
+        paidHours = hoursWorked - this.PAUSE_DEDUCTION;
+    }
+    
+    // Get wage rate and bonuses
+    const wageRate = this.getCurrentWageRate();
+    const bonuses = this.getCurrentBonuses();
+    const bonusType = shift.type === 0 ? 'weekday' : (shift.type === 1 ? 'saturday' : 'sunday');
+    const bonusSegments = bonuses[bonusType] || [];
+    
+    // Calculate earnings based on PAID hours
+    const baseEarned = paidHours * wageRate;
+    
+    // For bonus calculation, use adjusted end time
+    const adjustedMinutes = (paidHours * 60) + (startHour * 60) + startMinute;
+    const adjustedHour = Math.floor(adjustedMinutes / 60) % 24;
+    const adjustedMinute = adjustedMinutes % 60;
+    const adjustedTimeStr = `${adjustedHour.toString().padStart(2, '0')}:${adjustedMinute.toString().padStart(2, '0')}:${now.getSeconds().toString().padStart(2, '0')}`;
+    
+    const bonusEarned = this.calculateBonusWithSeconds(shift.startTime, adjustedTimeStr, bonusSegments);
+    
+    return {
+        totalHours: hoursWorked,              // Faktiske timer arbeidet
+        paidHours: paidHours,                 // Timer som betales
+        pauseDeducted: this.pauseDeduction && hoursWorked > this.PAUSE_THRESHOLD,
+        baseEarned: baseEarned,               // Grunnlønn basert på betalte timer
+        bonusEarned: bonusEarned,             // Tillegg basert på betalte timer
+        totalEarned: baseEarned + bonusEarned // Total basert på betalte timer
+    };
+}
+```
+
+### Alternativ 2: **Vis pausetrekk-info i UI**
+
+Legg til visual indikator når pausetrekk vil bli anvendt:
+
+```html
+<div class="pause-warning" style="display: ${hoursWorked > 5.5 && pauseDeduction ? 'block' : 'none'}">
+    <small>⚠️ Pausetrekk på 30 min vil bli trukket fra ved vaktens slutt</small>
+</div>
+```
+
+### Alternativ 3: **Real-time pausetrekk indikator**
+
+Vis både "brutto" og "netto" beløp i live-visningen:
+
+```html
+<div class="earnings-breakdown">
+    <div class="gross-earnings">Brutto: 1200 kr</div>
+    <div class="pause-deduction">- Pausetrekk: 80 kr</div>
+    <div class="net-earnings">Netto: 1120 kr</div>
+</div>
+```
+
+## Anbefaling
+
+**Implementer Alternativ 1** for å sikre konsistens mellom live-visning og endelig beregning. Dette vil:
+
+✅ Eliminere brukerforvirring  
+✅ Gi korrekte forventninger  
+✅ Sikre transparens i lønnssystemet  
+✅ Matche eksisterende pausetrekk-logikk  
+
+Tillegg: Kombinér med Alternativ 2 for ekstra tydlighet når pausetrekk blir anvendt.


### PR DESCRIPTION
Add database columns for flexible pause tracking per shift to enable consistent and transparent break time calculation.

The previous system ignored break deductions in live shift earnings, causing user confusion as final earnings differed from the live display. This PR introduces the necessary database structure and an implementation plan to allow users to define break start times and durations per shift, ensuring live earnings accurately reflect deductions and providing a "pause" badge for transparency.