### PR TITLE
Improve calendar DOM reuse

### DIFF
--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -203,6 +203,9 @@ export const app = {
     formState: {}, // Store form state to preserve across page restarts
     initialAnimationComplete: false, // Track if initial progress bar animation is complete
     nextShiftTimer: null, // Timer for updating next shift countdown
+    lastRenderedMonth: null,
+    lastRenderedYear: null,
+    lastRenderedShiftsKey: '',
     async init() {
         // Initialize selectedDates array for multiple date selection
         this.selectedDates = [];
@@ -2199,7 +2202,15 @@ export const app = {
 
     updateShiftCalendar() {
         if (this.shiftView !== 'calendar') return;
-        this.renderShiftCalendar();
+
+        const currentKey = this.getMonthShiftsKey();
+        if (this.lastRenderedMonth !== this.currentMonth ||
+            this.lastRenderedYear !== this.currentYear ||
+            this.lastRenderedShiftsKey !== currentKey) {
+            this.renderShiftCalendar();
+        } else {
+            this.updateCalendarCells();
+        }
     },
 
     updateLastUpdatedTime() {
@@ -2626,6 +2637,8 @@ export const app = {
 
                 const cell = document.createElement('div');
                 cell.className = 'calendar-cell';
+                const dateStr = `${cellDate.getFullYear()}-${String(cellDate.getMonth()+1).padStart(2,'0')}-${String(cellDate.getDate()).padStart(2,'0')}`;
+                cell.setAttribute('data-date', dateStr);
                 if (cellDate.getMonth() !== monthIdx) {
                     cell.classList.add('other-month');
                 }
@@ -2754,6 +2767,158 @@ export const app = {
         }
 
         container.appendChild(grid);
+
+        this.lastRenderedMonth = this.currentMonth;
+        this.lastRenderedYear = this.currentYear;
+        this.lastRenderedShiftsKey = this.getMonthShiftsKey();
+    },
+
+    updateCalendarCells() {
+        const cells = document.querySelectorAll('.calendar-cell');
+        const monthIdx = this.currentMonth - 1;
+        const year = this.currentYear;
+
+        // Filter shifts for current month only (consistent with renderShiftCalendar)
+        const monthShifts = this.shifts.filter(s =>
+            s.date.getMonth() === monthIdx &&
+            s.date.getFullYear() === year
+        );
+
+        // Create shifts by date lookup for current month
+        const shiftsByDate = {};
+        monthShifts.forEach(shift => {
+            const key = shift.date.getDate();
+            if (!shiftsByDate[key]) shiftsByDate[key] = [];
+            shiftsByDate[key].push(shift);
+        });
+
+        cells.forEach(cell => {
+            const dateStr = cell.getAttribute('data-date');
+            if (!dateStr) return;
+            const [y, m, d] = dateStr.split('-').map(n => parseInt(n, 10));
+            const cellDate = new Date(y, m - 1, d);
+
+            const content = cell.querySelector('.calendar-cell-content');
+            if (!content) return;
+            const oldData = content.querySelector('.calendar-shift-data');
+            if (oldData) oldData.remove();
+
+            cell.classList.remove('has-shifts', 'empty-date');
+
+            // Get shifts for this specific day (only from current month)
+            const shiftsForDay = shiftsByDate[cellDate.getDate()] || [];
+
+            // For other-month cells, only show shifts if they're in the current month
+            const isCurrentMonth = cellDate.getMonth() === monthIdx;
+            const shiftsToDisplay = isCurrentMonth ? shiftsForDay : [];
+
+            // Toggle hours-mode class
+            if (this.calendarDisplayMode === 'hours') {
+                cell.classList.add('hours-mode');
+            } else {
+                cell.classList.remove('hours-mode');
+            }
+
+            let base = 0;
+            let bonus = 0;
+            let totalHours = 0;
+            shiftsToDisplay.forEach(shift => {
+                const calc = this.calculateShift(shift);
+                base += calc.baseWage;
+                bonus += calc.bonus;
+                totalHours += calc.totalHours;
+            });
+
+            if ((this.calendarDisplayMode === 'money' && base + bonus > 0) ||
+                (this.calendarDisplayMode === 'hours' && shiftsToDisplay.length > 0)) {
+                const shiftData = document.createElement('div');
+                shiftData.className = 'calendar-shift-data';
+
+                if (this.calendarDisplayMode === 'money') {
+                    const breakdown = document.createElement('div');
+                    breakdown.className = 'calendar-breakdown';
+                    breakdown.innerHTML = `<div class="calendar-base-amount">${this.formatCurrencyShort(base)}</div><div class="calendar-bonus-line">+<span class="calendar-bonus-amount">${this.formatCurrencyShort(bonus)}</span></div>`;
+
+                    const totalDisplay = document.createElement('div');
+                    totalDisplay.className = 'calendar-total';
+                    totalDisplay.textContent = this.formatCurrencyCalendar(base + bonus);
+
+                    shiftData.appendChild(breakdown);
+                    shiftData.appendChild(totalDisplay);
+                } else {
+                    const hoursDisplay = document.createElement('div');
+                    hoursDisplay.className = 'calendar-hours-display';
+
+                    let earliestStartMinutes = Infinity;
+                    let latestEndMinutes = -Infinity;
+                    let earliestStartTime = '';
+                    let latestEndTime = '';
+                    let latestEndCrossedMidnight = false;
+
+                    shiftsToDisplay.forEach(shift => {
+                        const startMinutes = this.timeToMinutes(shift.startTime);
+                        let endMinutes = this.timeToMinutes(shift.endTime);
+                        let endCrossedMidnight = false;
+
+                        if (endMinutes < startMinutes) {
+                            endMinutes += 24 * 60;
+                            endCrossedMidnight = true;
+                        }
+
+                        if (startMinutes < earliestStartMinutes) {
+                            earliestStartMinutes = startMinutes;
+                            earliestStartTime = shift.startTime;
+                        }
+
+                        if (endMinutes > latestEndMinutes) {
+                            latestEndMinutes = endMinutes;
+                            latestEndTime = shift.endTime;
+                            latestEndCrossedMidnight = endCrossedMidnight;
+                        }
+                    });
+
+                    let endTimeDisplay = this.formatTimeShort(latestEndTime);
+                    if (latestEndCrossedMidnight) {
+                        endTimeDisplay += '*';
+                    }
+
+                    const timeRange = document.createElement('div');
+                    timeRange.className = 'calendar-total calendar-hours-total';
+                    if (latestEndCrossedMidnight) {
+                        timeRange.title = '* indicates the shift ends the next day';
+                    }
+                    timeRange.innerHTML = `${this.formatTimeShort(earliestStartTime)} -<br>${endTimeDisplay}`;
+
+                    hoursDisplay.appendChild(timeRange);
+                    shiftData.appendChild(hoursDisplay);
+                }
+
+                content.appendChild(shiftData);
+                cell.classList.add('has-shifts');
+                cell.style.cursor = 'pointer';
+
+                // Set up click handler for cells with shifts
+                cell.onclick = (e) => {
+                    e.stopPropagation();
+                    if (shiftsToDisplay.length > 0) {
+                        this.showShiftDetails(shiftsToDisplay[0].id);
+                    }
+                };
+            } else if (isCurrentMonth) {
+                cell.classList.add('empty-date');
+                cell.style.cursor = 'pointer';
+
+                // Set up click handler for empty cells in current month
+                cell.onclick = (e) => {
+                    e.stopPropagation();
+                    this.openAddShiftModalWithDate(cellDate);
+                };
+            } else {
+                // Remove click handlers for other-month cells without shifts
+                cell.onclick = null;
+                cell.style.cursor = 'default';
+            }
+        });
     },
 
     switchShiftView(view) {
@@ -2774,7 +2939,7 @@ export const app = {
             list.style.display = 'none';
             cal.style.display = 'flex';
             if (toggle) toggle.style.display = 'flex';
-            this.renderShiftCalendar();
+            this.updateShiftCalendar();
         } else {
             list.style.display = 'flex';
             cal.style.display = 'none';
@@ -2791,9 +2956,9 @@ export const app = {
             btn.classList.toggle('active', isActive);
         });
         
-        // Re-render calendar with new display mode
+        // Update calendar cells when in calendar view
         if (this.shiftView === 'calendar') {
-            this.renderShiftCalendar();
+            this.updateCalendarCells();
         }
     },
         // Show breakdown in calendar view (replaces modal)
@@ -5019,6 +5184,16 @@ export const app = {
     createShiftKey(shift) {
         const dateStr = `${shift.date.getFullYear()}-${(shift.date.getMonth() + 1).toString().padStart(2, '0')}-${shift.date.getDate().toString().padStart(2, '0')}`;
         return `${dateStr}_${shift.startTime}_${shift.endTime}_${shift.type}`;
+    },
+
+    getMonthShiftsKey() {
+        const monthIdx = this.currentMonth - 1;
+        const year = this.currentYear;
+        const monthShifts = this.shifts.filter(s =>
+            s.date.getMonth() === monthIdx &&
+            s.date.getFullYear() === year
+        );
+        return monthShifts.map(s => this.createShiftKey(s)).join('|');
     },
 
     // Save imported shifts to Supabase database


### PR DESCRIPTION
## Summary
- add bookkeeping for last rendered calendar details
- use `data-date` attribute for calendar cells
- add `updateCalendarCells` for updating calendar cell contents
- avoid full re-render on display mode change
- only re-render calendar when month/year or shift data changes
- refine calendar cell update logic and keep click handlers

## Testing
- `node -e "require('./kalkulator/js/appLogic.js');" && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_687c5cb4cde4832f8a201bd57dc528c7