### PR TITLE
Reposition serie badge in shift cards

### DIFF
--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -1970,7 +1970,7 @@ input:checked + .slider:before {
   left: 0;
   top: 0;
   bottom: 0;
-  width: 16px;
+  width: 32px;
   background: var(--bg-card);
   color: var(--text-secondary);
   font-size: 11px;
@@ -5243,10 +5243,10 @@ input[type="file"].form-control:focus {
 
 /* Adjust shift-info padding when series badge is present */
 .shift-item:has(.series-badge-left) .shift-info {
-  padding-left: 16px; /* Add extra padding to prevent overlap with badge (16px width + 6px spacing) */
+  padding-left: 20px; /* Reduced padding to bring main content closer to serie badge */
 }
 
 /* Adjust shift-info padding when both badges are present */
 .shift-item:has(.next-shift-badge):has(.series-badge-left) .shift-info {
-  padding-left: 48px; /* Add extra padding to prevent overlap with both badges (32px + 16px) */
+  padding-left: 52px; /* Add extra padding to prevent overlap with both badges (32px + 20px) */
 }

--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -1964,6 +1964,40 @@ input:checked + .slider:before {
   vertical-align: middle;
 }
 
+/* Series Badge Left - positioned like next shift badge */
+.series-badge-left {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 32px;
+  background: var(--gradient-progress-bg);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  
+  /* Create flat left edges, rounded right edge (reversed due to 180deg rotation) */
+  border-radius: 0 24px 24px 0;
+  
+  /* Text rotation - bottom facing inward */
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  transform: rotate(180deg);
+}
+
+/* When both next-shift-badge and series-badge-left are present, adjust positioning */
+.shift-item:has(.next-shift-badge):has(.series-badge-left) .series-badge-left {
+  left: 32px; /* Position series badge to the right of the next shift badge */
+  border-radius: 0 24px 24px 0; /* Keep the same border radius */
+}
+
 /* Content section with proper spacing from header */
 .content {
   padding-top: 0;
@@ -5033,6 +5067,29 @@ input[type="file"].form-control:focus {
   }
 }
 
+/* Responsive border radius for series badge left to match card */
+@media (max-width: 480px) {
+  .series-badge-left {
+    border-radius: 0 20px 20px 0;
+  }
+  
+  /* When both badges are present, adjust positioning for smaller screens */
+  .shift-item:has(.next-shift-badge):has(.series-badge-left) .series-badge-left {
+    left: 28px; /* Slightly smaller spacing on mobile */
+  }
+}
+
+@media (max-width: 360px) {
+  .series-badge-left {
+    border-radius: 0 16px 16px 0;
+  }
+  
+  /* When both badges are present, adjust positioning for very small screens */
+  .shift-item:has(.next-shift-badge):has(.series-badge-left) .series-badge-left {
+    left: 24px; /* Even smaller spacing on very small screens */
+  }
+}
+
 /* ============================================================================
    DATA TAB SPECIFIC STYLING - IMPROVED LAYOUT AND PADDING
    ============================================================================ */
@@ -5182,4 +5239,14 @@ input[type="file"].form-control:focus {
 /* Adjust shift-info padding to make room for the badge */
 .next-shift-card .shift-item .shift-info {
   padding-left: 32px; /* Add extra padding to prevent overlap with badge (32px width + 6px spacing) */
+}
+
+/* Adjust shift-info padding when series badge is present */
+.shift-item:has(.series-badge-left) .shift-info {
+  padding-left: 32px; /* Add extra padding to prevent overlap with badge (32px width + 6px spacing) */
+}
+
+/* Adjust shift-info padding when both badges are present */
+.shift-item:has(.next-shift-badge):has(.series-badge-left) .shift-info {
+  padding-left: 64px; /* Add extra padding to prevent overlap with both badges (32px + 32px) */
 }

--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -1970,7 +1970,7 @@ input:checked + .slider:before {
   left: 0;
   top: 0;
   bottom: 0;
-  width: 32px;
+  width: 24px;
   background: var(--bg-card);
   color: var(--text-secondary);
   font-size: 11px;
@@ -1990,16 +1990,12 @@ input:checked + .slider:before {
   writing-mode: vertical-rl;
   text-orientation: mixed;
   transform: rotate(180deg);
-  
-  /* Add a subtle border to separate from the rest of the card */
-  border-right: 1px solid var(--border);
 }
 
 /* When both next-shift-badge and series-badge-left are present, adjust positioning */
 .shift-item:has(.next-shift-badge):has(.series-badge-left) .series-badge-left {
   left: 32px; /* Position series badge to the right of the next shift badge */
   border-radius: 0 24px 24px 0; /* Keep the same border radius */
-  border-right: 1px solid var(--border); /* Maintain the border */
 }
 
 /* Content section with proper spacing from header */
@@ -5247,10 +5243,10 @@ input[type="file"].form-control:focus {
 
 /* Adjust shift-info padding when series badge is present */
 .shift-item:has(.series-badge-left) .shift-info {
-  padding-left: 32px; /* Add extra padding to prevent overlap with badge (32px width + 6px spacing) */
+  padding-left: 24px; /* Add extra padding to prevent overlap with badge (24px width + 6px spacing) */
 }
 
 /* Adjust shift-info padding when both badges are present */
 .shift-item:has(.next-shift-badge):has(.series-badge-left) .shift-info {
-  padding-left: 64px; /* Add extra padding to prevent overlap with both badges (32px + 32px) */
+  padding-left: 56px; /* Add extra padding to prevent overlap with both badges (32px + 24px) */
 }

--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -1970,7 +1970,7 @@ input:checked + .slider:before {
   left: 0;
   top: 0;
   bottom: 0;
-  width: 24px;
+  width: 16px;
   background: var(--bg-card);
   color: var(--text-secondary);
   font-size: 11px;
@@ -5243,10 +5243,10 @@ input[type="file"].form-control:focus {
 
 /* Adjust shift-info padding when series badge is present */
 .shift-item:has(.series-badge-left) .shift-info {
-  padding-left: 24px; /* Add extra padding to prevent overlap with badge (24px width + 6px spacing) */
+  padding-left: 16px; /* Add extra padding to prevent overlap with badge (16px width + 6px spacing) */
 }
 
 /* Adjust shift-info padding when both badges are present */
 .shift-item:has(.next-shift-badge):has(.series-badge-left) .shift-info {
-  padding-left: 56px; /* Add extra padding to prevent overlap with both badges (32px + 24px) */
+  padding-left: 48px; /* Add extra padding to prevent overlap with both badges (32px + 16px) */
 }

--- a/kalkulator/css/style.css
+++ b/kalkulator/css/style.css
@@ -1971,7 +1971,7 @@ input:checked + .slider:before {
   top: 0;
   bottom: 0;
   width: 32px;
-  background: var(--gradient-progress-bg);
+  background: var(--bg-card);
   color: var(--text-secondary);
   font-size: 11px;
   font-weight: 600;
@@ -1990,12 +1990,16 @@ input:checked + .slider:before {
   writing-mode: vertical-rl;
   text-orientation: mixed;
   transform: rotate(180deg);
+  
+  /* Add a subtle border to separate from the rest of the card */
+  border-right: 1px solid var(--border);
 }
 
 /* When both next-shift-badge and series-badge-left are present, adjust positioning */
 .shift-item:has(.next-shift-badge):has(.series-badge-left) .series-badge-left {
   left: 32px; /* Position series badge to the right of the next shift badge */
   border-radius: 0 24px 24px 0; /* Keep the same border radius */
+  border-right: 1px solid var(--border); /* Maintain the border */
 }
 
 /* Content section with proper spacing from header */

--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -2164,15 +2164,16 @@ export const app = {
                 const day = shift.date.getDate();
                 const weekday = this.WEEKDAYS[shift.date.getDay()];
                 const typeClass = shift.type === 0 ? 'weekday' : (shift.type === 1 ? 'saturday' : 'sunday');
-                const seriesBadge = shift.seriesId ? '<span class="series-badge">Serie</span>' : '';
+                const seriesBadge = shift.seriesId ? '<div class="series-badge-left">Serie</div>' : '';
                 
                 shiftsHtml.push(`
-                    <div class="shift-item ${typeClass}" data-shift-id="${shift.id}" style="cursor: pointer;">
+                    <div class="shift-item ${typeClass}" data-shift-id="${shift.id}" style="cursor: pointer; position: relative;">
+                        ${seriesBadge}
                         <div class="shift-info">
                             <div class="shift-date">
                                 <span class="shift-date-number">${day}. ${this.MONTHS[shift.date.getMonth()]}</span>
                                 <span class="shift-date-separator"></span>
-                                <span class="shift-date-weekday">${weekday}${seriesBadge}</span>
+                                <span class="shift-date-weekday">${weekday}</span>
                             </div>
                             <div class="shift-details">
                                 <div class="shift-time-with-hours">
@@ -2337,7 +2338,7 @@ export const app = {
             
             // Create the shift item using the exact same structure as in the shift list
             const typeClass = nextShift.type === 0 ? 'weekday' : (nextShift.type === 1 ? 'saturday' : 'sunday');
-            const seriesBadge = nextShift.seriesId ? '<span class="series-badge">Serie</span>' : '';
+            const seriesBadge = nextShift.seriesId ? '<div class="series-badge-left">Serie</div>' : '';
             
             // Add time remaining for today's shifts or "i morgen" for tomorrow's shifts
             let dateSuffix = '';
@@ -2375,11 +2376,12 @@ export const app = {
             nextShiftContent.innerHTML = `
                 <div class="shift-item ${typeClass}${activeClass}" data-shift-id="${nextShift.id}" style="cursor: pointer; position: relative;">
                     <div class="next-shift-badge">Neste</div>
+                    ${seriesBadge}
                     <div class="shift-info">
                         <div class="shift-date">
                             <span class="shift-date-number">${day}. ${month}</span>
                             <span class="shift-date-separator"></span>
-                            <span class="shift-date-weekday">${weekday}${seriesBadge}</span>
+                            <span class="shift-date-weekday">${weekday}</span>
                             <span class="shift-countdown-timer">${dateSuffix}</span>
                         </div>
                         <div class="shift-details">
@@ -2447,16 +2449,17 @@ export const app = {
         }
         
         const typeClass = currentShift.type === 0 ? 'weekday' : (currentShift.type === 1 ? 'saturday' : 'sunday');
-        const seriesBadge = currentShift.seriesId ? '<span class="series-badge">Serie</span>' : '';
+        const seriesBadge = currentShift.seriesId ? '<div class="series-badge-left">Serie</div>' : '';
         
         nextShiftContent.innerHTML = `
             <div class="shift-item ${typeClass} active" data-shift-id="${currentShift.id}" style="cursor: pointer; position: relative;">
                 <div class="next-shift-badge">NÅ</div>
+                ${seriesBadge}
                 <div class="shift-info">
                     <div class="shift-date">
                         <span class="shift-date-number">${day}. ${month}</span>
                         <span class="shift-date-separator"></span>
-                        <span class="shift-date-weekday">${weekday}${seriesBadge}</span>
+                        <span class="shift-date-weekday">${weekday}</span>
                         <span class="shift-countdown-timer"> ${timeWorkedText}</span>
                     </div>
                     <div class="shift-details">

--- a/kalkulator/js/appLogic.js
+++ b/kalkulator/js/appLogic.js
@@ -2338,7 +2338,7 @@ export const app = {
             
             // Create the shift item using the exact same structure as in the shift list
             const typeClass = nextShift.type === 0 ? 'weekday' : (nextShift.type === 1 ? 'saturday' : 'sunday');
-            const seriesBadge = nextShift.seriesId ? '<div class="series-badge-left">Serie</div>' : '';
+            const seriesBadge = ''; // Never show series badge in next shift card
             
             // Add time remaining for today's shifts or "i morgen" for tomorrow's shifts
             let dateSuffix = '';
@@ -2449,7 +2449,7 @@ export const app = {
         }
         
         const typeClass = currentShift.type === 0 ? 'weekday' : (currentShift.type === 1 ? 'saturday' : 'sunday');
-        const seriesBadge = currentShift.seriesId ? '<div class="series-badge-left">Serie</div>' : '';
+        const seriesBadge = ''; // Never show series badge in current shift card
         
         nextShiftContent.innerHTML = `
             <div class="shift-item ${typeClass} active" data-shift-id="${currentShift.id}" style="cursor: pointer; position: relative;">


### PR DESCRIPTION
Move 'serie' badge to the left side of shift cards for consistent styling with 'Neste' badge.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-b31cb819-f242-4bec-a4ce-ab5bba5a2475) · [Cursor](https://cursor.com/background-agent?bcId=bc-b31cb819-f242-4bec-a4ce-ab5bba5a2475)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)