### PR TITLE
Harden avatar uploads and sanitize employee menu text

### DIFF
--- a/docs/OPENAPI.yaml
+++ b/docs/OPENAPI.yaml
@@ -262,7 +262,7 @@ paths:
               properties:
                 image_base64:
                   type: string
-                  description: Base64-encoded JPEG image data (no data URL prefix)
+                  description: Base64-encoded JPEG or PNG image data (max 1MB, no data URL prefix)
       responses:
         '200':
           description: OK

--- a/kalkulator/js/employeeActionsMenu.js
+++ b/kalkulator/js/employeeActionsMenu.js
@@ -71,34 +71,51 @@ export class EmployeeActionsMenu {
         this.currentMenu.setAttribute('role', 'menu');
         this.currentMenu.setAttribute('aria-label', `Handlinger for ${employee.name}`);
         
-        // Create menu items
-        const menuItems = this.createMenuItems(employee);
-        this.currentMenu.innerHTML = `
-            <div class="menu-header">
-                <div class="menu-employee-info">
-                    <div class="menu-employee-avatar" style="--employee-color: ${this.app.getEmployeeDisplayColor(employee)}">
-                        ${this.getEmployeeAvatarContent(employee)}
-                    </div>
-                    <div class="menu-employee-name">${employee.name}</div>
-                </div>
-                <button class="menu-close-btn" aria-label="Lukk meny">
+        // Build header structure without using innerHTML for user data
+        const header = document.createElement('div');
+        header.className = 'menu-header';
+
+        const info = document.createElement('div');
+        info.className = 'menu-employee-info';
+
+        const avatar = document.createElement('div');
+        avatar.className = 'menu-employee-avatar';
+        avatar.style.setProperty('--employee-color', this.app.getEmployeeDisplayColor(employee));
+        avatar.appendChild(this.getEmployeeAvatarContent(employee));
+
+        const nameEl = document.createElement('div');
+        nameEl.className = 'menu-employee-name';
+        nameEl.textContent = employee.name;
+
+        info.appendChild(avatar);
+        info.appendChild(nameEl);
+
+        const closeBtn = document.createElement('button');
+        closeBtn.className = 'menu-close-btn';
+        closeBtn.setAttribute('aria-label', 'Lukk meny');
+        closeBtn.innerHTML = `
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <line x1="18" y1="6" x2="6" y2="18"></line>
                         <line x1="6" y1="6" x2="18" y2="18"></line>
                     </svg>
-                </button>
-            </div>
-            <div class="menu-items">
-                ${menuItems}
-            </div>
-        `;
+                `;
+
+        header.appendChild(info);
+        header.appendChild(closeBtn);
+
+        const itemsContainer = document.createElement('div');
+        itemsContainer.className = 'menu-items';
+        itemsContainer.innerHTML = this.createMenuItems(employee);
+
+        this.currentMenu.appendChild(header);
+        this.currentMenu.appendChild(itemsContainer);
 
         // Position the menu
         this.positionMenu(triggerElement, options);
-        
+
         // Add to DOM
         document.body.appendChild(this.currentMenu);
-        
+
         // Focus first menu item
         setTimeout(() => {
             const firstItem = this.currentMenu.querySelector('.menu-item');
@@ -168,7 +185,10 @@ export class EmployeeActionsMenu {
     getEmployeeAvatarContent(employee) {
         // This will be enhanced when avatar loading is implemented
         const initials = this.app.getEmployeeInitials(employee);
-        return `<div class="avatar-initials">${initials}</div>`;
+        const div = document.createElement('div');
+        div.className = 'avatar-initials';
+        div.textContent = initials;
+        return div;
     }
 
     /**


### PR DESCRIPTION
## Summary
- prevent XSS in employee action menu by assigning user data via `textContent`
- add file size and MIME type validation for `/user/avatar` uploads
- document avatar upload restrictions in OpenAPI spec

## Testing
- `npm test` *(fails: Cannot find module dev-tests/test-duplicate-shifts.js)*

------
https://chatgpt.com/codex/tasks/task_e_689d15bd4d84832f8a4c2620296878d5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Avatar uploads now support PNG in addition to JPEG.
  - Enforced 1MB size limit and file type validation for avatar uploads; responses include the public URL on success.
- Refactor
  - Employee actions menu header rebuilt using DOM elements for more consistent avatar rendering and a dedicated close button, with no change to menu behavior.
- Documentation
  - OpenAPI updated for /user/avatar to reflect PNG support and the 1MB limit, clarifying base64 requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->