### PR TITLE
Refine focus styling and theme tokens

### DIFF
--- a/app/src/css/legal-modal.css
+++ b/app/src/css/legal-modal.css
@@ -144,9 +144,10 @@ body {
     color: var(--text-primary, #111827);
 }
 
-.legal-modal-close:focus {
-    outline: 2px solid var(--accent, #3b82f6);
+.legal-modal-close:focus-visible {
+    outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
     outline-offset: 2px;
+    box-shadow: var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45));
 }
 
 .legal-modal-tabs {
@@ -179,9 +180,10 @@ body {
     background: var(--bg-primary, #ffffff);
 }
 
-.legal-tab:focus {
-    outline: 2px solid var(--accent, #3b82f6);
+.legal-tab:focus-visible {
+    outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
     outline-offset: -2px;
+    box-shadow: var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45));
 }
 
 .legal-modal-content {

--- a/app/src/css/onboarding.css
+++ b/app/src/css/onboarding.css
@@ -44,7 +44,12 @@ body.onboarding-route {
 .form-group { margin-bottom: var(--space-4); }
 .form-label { display: block; font-size: var(--text-sm); font-weight: var(--font-weight-medium); color: var(--text-primary); margin-bottom: var(--space-1); }
 .form-control { width: 100%; padding: var(--space-3); border: 1px solid var(--border); border-radius: var(--border-radius); background: var(--bg-card-elevated); color: var(--text-primary); font-size: var(--text-base); transition: all var(--speed-normal) var(--ease-default); }
-.form-control:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 3px rgba(74, 200, 255, 0.1); }
+.form-control:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
+  border-color: var(--primary);
+  box-shadow: var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45)), 0 0 0 3px rgba(74, 200, 255, 0.1);
+}
 .form-control.error { border-color: var(--error); background-color: rgba(239, 68, 68, 0.05); }
 .form-error { color: var(--error); font-size: var(--text-xs); margin-top: var(--space-1); display: none; }
 .form-error.show { display: block; }
@@ -123,7 +128,12 @@ input:checked + .slider:before { transform: translateX(26px); }
 .bonus-slot-field { display: flex; flex-direction: column; gap: var(--space-1); }
 .bonus-slot-label { font-size: var(--text-xs); font-weight: var(--font-weight-medium); color: var(--text-secondary); margin-bottom: 2px; text-align: left; }
 .bonus-slot input { padding: var(--space-2); border: 1px solid var(--border); border-radius: var(--border-radius); background: var(--bg-primary); color: var(--text-primary); font-size: var(--text-sm); }
-.bonus-slot input:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 2px rgba(74, 200, 255, 0.1); }
+.bonus-slot input:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
+  border-color: var(--primary);
+  box-shadow: var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45)), 0 0 0 2px rgba(74, 200, 255, 0.1);
+}
 .remove-bonus-btn { background: var(--error); color: white; border: none; padding: var(--space-1); border-radius: 50%; cursor: pointer; transition: all var(--speed-normal) var(--ease-default); display: flex; align-items: center; justify-content: center; width: 24px; height: 24px; position: absolute; top: -8px; right: -8px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2); z-index: 1; }
 .remove-bonus-btn:hover { background: var(--error-dark); transform: scale(1.1); }
 .btn-add-bonus { background: none; border: 2px dashed var(--border); color: var(--text-secondary); padding: var(--space-3); border-radius: var(--border-radius); cursor: pointer; transition: all var(--speed-normal) var(--ease-default); }

--- a/app/src/css/settings.css
+++ b/app/src/css/settings.css
@@ -418,9 +418,15 @@ html.ios-pwa #shiftAddPage .tab-content {
   box-shadow: 0 0 6px rgba(255, 140, 0, 0.35);
 }
 .floating-nav-btn.back-btn.conflict:hover,
-.floating-nav-btn.back-btn.conflict:focus {
+.floating-nav-btn.back-btn.conflict:focus-visible {
   background: #e67c00;
   border-color: #e67c00;
+}
+
+.floating-nav-btn.back-btn.conflict:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
+  box-shadow: var(--focus-ring-strong, 0 0 0 2px rgba(74, 200, 255, 0.3));
 }
 
 .floating-nav-btn.btn.btn-secondary {
@@ -937,12 +943,14 @@ html.ios-pwa #shiftAddPage .tab-content {
   transform: translateY(-1px);
 }
 
-#accountName:focus,
-#accountEmail:focus {
-  outline: none;
+#accountName:focus-visible,
+#accountEmail:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   border-color: var(--accent);
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.08) 0%, var(--bg-card-elevated) 100%);
   box-shadow:
+    var(--focus-ring-strong, 0 0 0 2px rgba(74, 200, 255, 0.3)),
     0 6px 20px rgba(0, 0, 0, 0.12),
     0 0 0 4px rgba(99, 102, 241, 0.15),
     inset 0 1px 0 rgba(255, 255, 255, 0.1);

--- a/app/src/css/style.css
+++ b/app/src/css/style.css
@@ -145,7 +145,10 @@ body:not(.dashboard-cards-loaded) .total-card {
   display: flex;
   align-items: center;
   cursor: pointer;
-  transition: all var(--speed-normal) var(--ease-default);
+  transition: transform var(--speed-normal) var(--ease-default),
+              box-shadow var(--speed-normal) var(--ease-default),
+              background-color var(--speed-normal) var(--ease-default),
+              border-color var(--speed-normal) var(--ease-default);
   opacity: 0.9;
 }
 
@@ -157,7 +160,8 @@ body:not(.dashboard-cards-loaded) .total-card {
 }
 
 .progress-card:focus-visible {
-  outline: none;
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   background: var(--surface-card-hover);
   border: var(--card-border-focus);
   box-shadow: var(--shadow-card-hover), var(--focus-ring);
@@ -257,7 +261,10 @@ body:not(.dashboard-cards-loaded) .total-card {
     0 0 8px rgba(0, 0, 0, 0.2);
 
   /* Smooth transitions for any text changes */
-  transition: all var(--speed-normal) var(--ease-default);
+  transition: transform var(--speed-normal) var(--ease-default),
+              box-shadow var(--speed-normal) var(--ease-default),
+              background-color var(--speed-normal) var(--ease-default),
+              border-color var(--speed-normal) var(--ease-default);
 
   /* Ensure consistent rendering across browsers */
   backface-visibility: hidden;
@@ -645,21 +652,18 @@ button {
 }
 
 /* Performance optimizations for animations */
-* {
-  /* Optimize animations for better performance */
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
-  -webkit-perspective: 1000;
-  perspective: 1000;
-}
-
-/* Elements that will be animated should declare will-change */
+/* Scoped to animated components only */
 .progress-fill,
 .modal-content,
 .shift-item,
 .calendar-cell,
 .btn,
 .tab-btn {
+  /* Optimize animations for better performance */
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  -webkit-perspective: 1000;
+  perspective: 1000;
   will-change: transform, opacity;
 }
 
@@ -717,7 +721,7 @@ button {
 
 /* Accessibility - Focus management */
 .focus-visible {
-  outline: 2px solid var(--primary);
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
   outline-offset: 2px;
 }
 
@@ -2540,19 +2544,34 @@ body.force-dashboard-nav .shift-section .month-navigation-container {
   justify-content: center;
   padding: 0;
   font-size: var(--text-lg); /* Increased from text-base for better visibility */
-  box-shadow:
-    0 2px 8px rgba(0, 0, 0, 0.04),
-    inset 0 1px 0 rgba(255, 255, 255, 0.02);
-  transition: all var(--speed-normal) var(--ease-default);
+  transition:
+    transform var(--speed-normal) var(--ease-default),
+    box-shadow var(--speed-normal) var(--ease-default),
+    background-color var(--speed-normal) var(--ease-default),
+    border-color var(--speed-normal) var(--ease-default);
   width: 48px; /* Increased from 40px for better touch target */
   height: 48px; /* Increased from 40px for better touch target */
   /* Subtle 3D Bevel Effect - consistent with other card elements */
   box-shadow:
-    0 2px 6px rgba(0, 0, 0, 0.06), /* Subtle depth shadow */
+    0 2px 8px rgba(0, 0, 0, 0.06),
     inset 0 1px 0 rgba(255, 255, 255, 0.05), /* Subtle top inner highlight */
     inset 0 -1px 0 rgba(0, 0, 0, 0.1), /* Subtle bottom inner shadow */
     inset 1px 0 0 rgba(255, 255, 255, 0.025), /* Subtle left inner highlight */
     inset -1px 0 0 rgba(0, 0, 0, 0.05); /* Subtle right inner shadow */
+}
+
+.month-nav-btn:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
+  border-color: transparent;
+  box-shadow:
+    var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45)),
+    0 0 0 3px rgba(99, 102, 241, 0.2),
+    0 2px 8px rgba(0, 0, 0, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.1),
+    inset 1px 0 0 rgba(255, 255, 255, 0.025),
+    inset -1px 0 0 rgba(0, 0, 0, 0.05);
 }
 
 .month-nav-btn:hover {
@@ -2716,15 +2735,13 @@ body.force-dashboard-nav .shift-section .month-navigation-container {
   font-size: var(--text-base); /* Prevents zoom on iOS */
   /* Subtle 3D Bevel Effect - consistent with other interactive elements */
   box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.04),
     0 1px 3px rgba(0, 0, 0, 0.04), /* Very subtle depth shadow */
     inset 0 1px 0 rgba(0, 0, 0, 0.08), /* Subtle inward top shadow for input appearance */
     inset 0 -1px 0 rgba(255, 255, 255, 0.03), /* Subtle inward bottom highlight */
     inset 1px 0 0 rgba(0, 0, 0, 0.04), /* Subtle inward left shadow */
     inset -1px 0 0 rgba(255, 255, 255, 0.02); /* Subtle inward right highlight */
   width: 100%;
-  box-shadow:
-    0 2px 8px rgba(0, 0, 0, 0.04),
-    inset 0 1px 0 rgba(255, 255, 255, 0.02);
   /* Optimized transitions - only animate specific properties */
   transition: border-color var(--speed-normal) var(--ease-default),
               box-shadow var(--speed-normal) var(--ease-default),
@@ -2746,23 +2763,20 @@ select.form-control {
   background-color: rgba(255, 255, 255, 0.02);
 }
 
-.form-control:focus {
-  outline: none;
+.form-control:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   border-color: rgba(99, 102, 241, 0.6);
   background-color: rgba(255, 255, 255, 0.03);
   /* Enhanced 3D Bevel Effect on focus - slightly more prominent for interactivity feedback */
   box-shadow:
+    var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45)),
     0 4px 12px rgba(0, 0, 0, 0.08), /* Enhanced depth shadow */
-    0 0 0 3px rgba(99, 102, 241, 0.1), /* Focus ring */
+    0 0 0 3px rgba(99, 102, 241, 0.1), /* Additional glow */
     inset 0 1px 0 rgba(0, 0, 0, 0.1), /* Enhanced inward top shadow */
     inset 0 -1px 0 rgba(255, 255, 255, 0.05), /* Enhanced inward bottom highlight */
     inset 1px 0 0 rgba(0, 0, 0, 0.06), /* Enhanced inward left shadow */
     inset -1px 0 0 rgba(255, 255, 255, 0.03); /* Enhanced inward right highlight */
-}
-
-.form-control:focus-visible {
-  outline: 2px solid var(--primary);
-  outline-offset: 2px;
 }
 
 /* Time Input Enhancements */
@@ -2789,8 +2803,8 @@ input[type="time"].form-control[value=""] {
 }
 
 /* Add subtle animation to draw attention to empty time fields */
-input[type="time"].form-control:invalid:focus,
-input[type="time"].form-control[value=""]:focus {
+input[type="time"].form-control:invalid:focus-visible,
+input[type="time"].form-control[value=""]:focus-visible {
   animation: subtle-pulse 2s ease-in-out infinite;
 }
 
@@ -2850,7 +2864,7 @@ input[type="time"].form-control[value=""]:focus {
   letter-spacing: normal;
 }
 
-.time-input:focus {
+.time-input:focus-visible {
   text-align: center;
 }
 
@@ -2860,7 +2874,7 @@ input[type="time"].form-control[value=""]:focus {
   background-color: rgba(255, 184, 107, 0.05);
 }
 
-.time-input:invalid:focus {
+.time-input:invalid:focus-visible {
   border-color: rgba(255, 107, 129, 0.6);
   background-color: rgba(255, 107, 129, 0.05);
 }
@@ -3063,8 +3077,9 @@ input[type="time"].form-control[value=""]:focus {
 }
 
 .btn:focus-visible {
-  outline: 2px solid var(--primary);
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
   outline-offset: 2px;
+  box-shadow: var(--focus-ring);
 }
 
 .btn:disabled {
@@ -3206,6 +3221,7 @@ input[type="time"].form-control[value=""]:focus {
   height: auto;
   /* Subtle 3D Bevel Effect - consistent with other card elements */
   box-shadow:
+    0 20px 60px rgba(0, 0, 0, 0.3),
     0 8px 32px rgba(0, 0, 0, 0.12), /* Enhanced depth shadow for modals */
     inset 0 1px 0 rgba(255, 255, 255, 0.05), /* Subtle top inner highlight */
     inset 0 -1px 0 rgba(0, 0, 0, 0.1), /* Subtle bottom inner shadow */
@@ -3215,9 +3231,6 @@ input[type="time"].form-control[value=""]:focus {
   -webkit-overflow-scrolling: touch; /* Momentum scrolling for iOS */
   position: relative;
   border: 1px solid var(--border);
-  box-shadow:
-    0 20px 60px rgba(0, 0, 0, 0.3),
-    inset 0 1px 0 rgba(255, 255, 255, 0.05);
   animation: gradientSlide 0.5s ease;
 }
 
@@ -5262,7 +5275,8 @@ input:checked + .slider:before {
 }
 
 .total-card:focus-visible {
-  outline: none;
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   background: var(--surface-card-hover);
   border: var(--card-border-focus);
   box-shadow: var(--shadow-card-hover), var(--focus-ring);
@@ -5559,7 +5573,6 @@ input:checked + .slider:before {
   position: relative;
   min-height: 45px;
   text-align: center;
-  outline: none;
   /* Initially hidden for animation */
   opacity: 0;
   animation: calendarCellFadeIn 0.2s var(--ease-default) forwards; /* Reduced from 0.3s */
@@ -5937,7 +5950,8 @@ input:checked + .slider:before {
 
 .next-shift-card .shift-item:focus-visible,
 .next-payroll-card .payroll-item:focus-visible {
-  outline: none;
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   background: var(--surface-card-hover);
   border: var(--card-border-focus);
   transform: translateY(-1px);
@@ -7290,7 +7304,6 @@ input:checked + .slider:before {
   height: 6px;
   border-radius: 3px;
   background: var(--bg-tertiary);
-  outline: none;
   border: none;
   cursor: pointer;
   -webkit-appearance: none;
@@ -7564,13 +7577,15 @@ input:checked + .slider:before {
 
 /* Add focus states for accessibility */
 .zoom-btn:focus-visible {
-  outline: 2px solid var(--primary);
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
   outline-offset: 2px;
+  box-shadow: var(--focus-ring);
 }
 
 .zoom-slider:focus-visible {
-  outline: 2px solid var(--primary);
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
   outline-offset: 4px;
+  box-shadow: var(--focus-ring);
 }
 
 .modal .form-group label {
@@ -8441,7 +8456,8 @@ body.chatbox-view .dashboard-content {
 }
 
 .floating-action-bar .add-btn:focus-visible {
-  outline: none;
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   background: var(--button-primary-bg-active);
   border-color: transparent;
   box-shadow: var(--shadow-card-hover-base), var(--focus-ring-strong);
@@ -9366,9 +9382,12 @@ input[type="file"].form-control:hover {
   background-color: rgba(255, 255, 255, 0.02);
 }
 
-input[type="file"].form-control:focus {
+input[type="file"].form-control:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   border-color: rgba(99, 102, 241, 0.4);
   background-color: rgba(255, 255, 255, 0.03);
+  box-shadow: var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45));
 }
 
 /* Import button - subtle styling */
@@ -11404,12 +11423,19 @@ input[type="file"].form-control:focus {
   transform: translateY(-1px);
 }
 
-.tab-btn:focus-visible {
-  outline: none;
+.tab-btn:focus-visible:not(.active) {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   background: var(--surface-card-hover);
   border: var(--card-border-focus);
   color: var(--text-primary);
   box-shadow: var(--focus-ring);
+}
+
+.tab-btn.active:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
+  box-shadow: var(--shadow-card-strong), var(--focus-ring-strong);
 }
 
 /* Active tab button styling */
@@ -12282,15 +12308,17 @@ body.chatbox-view .chatbox-container {
   box-sizing: border-box;
 }
 
-.employee-form .form-input:focus {
+.employee-form .form-input:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   border-color: var(--primary);
-  box-shadow: 
+  box-shadow:
+    var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45)),
     0 0 0 3px rgba(74, 200, 255, 0.1),
     0 4px 12px rgba(0, 0, 0, 0.15);
-  outline: none;
 }
 
-.employee-form .form-input:hover:not(:focus) {
+.employee-form .form-input:hover:not(:focus-visible) {
   border-color: rgba(74, 200, 255, 0.3);
   background: rgba(255, 255, 255, 0.02);
 }
@@ -12563,10 +12591,13 @@ body.chatbox-view .chatbox-container {
   transform: translateY(-2px);
 }
 
-.employee-tile:focus {
-  outline: none;
+.employee-tile:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+  box-shadow:
+    var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45)),
+    0 0 0 2px rgba(99, 102, 241, 0.2);
 }
 
 .employee-tile.active {
@@ -12586,7 +12617,7 @@ body.chatbox-view .chatbox-container {
 }
 
 .employee-tile:hover .employee-actions-btn,
-.employee-tile:focus .employee-actions-btn {
+.employee-tile:focus-visible .employee-actions-btn {
   opacity: 1;
   transform: scale(1);
 }
@@ -12601,7 +12632,7 @@ body.chatbox-view .chatbox-container {
     min-height: 44px;
   }
 
-  .employee-tile:focus {
+  .employee-tile:focus-visible {
     transform: scale(1.05);
     z-index: 2;
   }
@@ -13123,10 +13154,13 @@ body.chatbox-view .chatbox-container {
   background: rgba(255, 255, 255, 0.02);
 }
 
-.date-select:focus {
+.date-select:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   border-color: var(--primary);
-  box-shadow: 0 0 0 3px rgba(74, 200, 255, 0.1);
-  outline: none;
+  box-shadow:
+    var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45)),
+    0 0 0 3px rgba(74, 200, 255, 0.1);
 }
 
 /* Global Corner Radius Consistency */
@@ -13454,10 +13488,11 @@ body.chatbox-view .chatbox-container {
   box-sizing: border-box;
 }
 
-.form-input:focus {
-  outline: none;
+.form-input:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+  box-shadow: var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45)), 0 0 0 2px rgba(99, 102, 241, 0.2);
   background: var(--bg-secondary);
 }
 
@@ -13516,7 +13551,7 @@ body.chatbox-view .chatbox-container {
     border-width: 2px;
   }
 
-  .form-input:focus {
+  .form-input:focus-visible {
     border-width: 3px;
   }
 }
@@ -13620,8 +13655,8 @@ body.chatbox-view .chatbox-container {
   text-decoration: none;
 }
 
-.link-button:focus {
-  outline: 2px solid var(--accent);
+.link-button:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
   outline-offset: 2px;
   border-radius: 2px;
 }
@@ -14302,11 +14337,13 @@ body.chatbox-view .chatbox-container {
   color: var(--text-primary);
 }
 
-.menu-item:focus {
-  outline: none;
+.menu-item:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   background: rgba(99, 102, 241, 0.1);
+  border: var(--card-border);
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+  box-shadow: var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45));
 }
 
 .menu-item.destructive {
@@ -14463,7 +14500,7 @@ body.chatbox-view .chatbox-container {
     border-bottom-width: 2px;
   }
 
-  .menu-item:focus {
+  .menu-item:focus-visible {
     border: 2px solid var(--accent);
   }
 
@@ -15220,9 +15257,11 @@ body.chatbox-view .chatbox-container {
   font-family: inherit;
 }
 
-.chatbox-input:focus {
-  outline: none;
+.chatbox-input:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+  outline-offset: 2px;
   border-color: var(--primary);
+  box-shadow: var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45));
 }
 
 .chatbox-input::placeholder {
@@ -15435,10 +15474,12 @@ body.chatbox-view .chatbox-container {
   }
 
   /* Improve input focus behavior */
-  .chatbox-input:focus {
-    outline: none;
+  .chatbox-input:focus-visible {
+    outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+    outline-offset: 2px;
     border-color: var(--primary);
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+    box-shadow: var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45)),
+                0 0 0 2px rgba(59, 130, 246, 0.1);
   }
 
   /* Ensure text container maintains consistent layout */
@@ -15643,13 +15684,17 @@ body.chatbox-view .chatbox-container {
   }
 
   /* Enhanced input field behavior for mobile keyboard */
-  body.keyboard-visible .chatbox-input:focus {
+  body.keyboard-visible .chatbox-input:focus-visible {
     /* Ensure input stays visible above keyboard */
     position: relative;
     z-index: 1002;
     background: var(--bg-primary);
     border: 2px solid var(--primary);
-    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15), 0 4px 20px rgba(0, 0, 0, 0.1);
+    outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
+    outline-offset: 2px;
+    box-shadow: var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45)),
+                0 0 0 3px rgba(59, 130, 246, 0.15),
+                0 4px 20px rgba(0, 0, 0, 0.1);
   }
 
   /* Enable smooth scroll for better user experience during keyboard positioning */
@@ -15838,9 +15883,10 @@ body.chatbox-view .chatbox-container {
   transform: translateY(-1px);
 }
 
-.filter-chip:focus {
-  outline: 2px solid var(--primary);
+.filter-chip:focus-visible {
+  outline: var(--focus-outline-width, 2px) solid var(--focus-outline-color, rgba(74, 200, 255, 0.9));
   outline-offset: 2px;
+  box-shadow: var(--focus-ring, 0 0 0 1px rgba(74, 200, 255, 0.45));
 }
 
 .filter-chip.active {

--- a/app/src/css/themes.css
+++ b/app/src/css/themes.css
@@ -41,8 +41,8 @@
   --speed-slow: 0.5s;
   --ease-default: cubic-bezier(0.4, 0, 0.2, 1);
   --ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
-  --border-radius: 40px;
-  --border-radius-large: 40px;
+  --border-radius: var(--radius-3xl);
+  --border-radius-large: var(--radius-3xl);
 
   /* Corner radius scale (8px rhythm) */
   --radius-xs: 4px;
@@ -62,11 +62,18 @@
   --surface-card-hover: rgba(74, 200, 255, 0.08);
   --surface-card-press: rgba(74, 200, 255, 0.05);
   --surface-card-active: var(--gradient-secondary);
+  --surface-card-disabled: color-mix(in oklab, var(--bg-card), transparent 30%);
 
   /* Border tokens */
-  --card-border: 1px solid var(--border);
-  --card-border-strong: 1px solid rgba(74, 200, 255, 0.35);
-  --card-border-focus: 1px solid rgba(74, 200, 255, 0.55);
+  --card-border-width: 1px;
+  --card-border-style: solid;
+  --card-border-color: var(--border);
+  --card-border: var(--card-border-width) var(--card-border-style) var(--card-border-color);
+  --card-border-strong-color: rgba(74, 200, 255, 0.35);
+  --card-border-focus-color: rgba(74, 200, 255, 0.55);
+  --card-border-strong: var(--card-border-width) var(--card-border-style) var(--card-border-strong-color);
+  --card-border-focus: var(--card-border-width) var(--card-border-style) var(--card-border-focus-color);
+  --card-border-width-strong: 2px;
 
   /* Shadow tokens */
   --shadow-card-base: 0 12px 32px rgba(8, 12, 20, 0.45);
@@ -91,10 +98,13 @@
     var(--shadow-card-inset-bottom),
     var(--shadow-card-inset-left),
     var(--shadow-card-inset-right);
+  --shadow-card-lite: 0 8px 16px rgba(0, 0, 0, 0.25);
 
   /* Focus rings */
   --focus-ring: 0 0 0 1px rgba(74, 200, 255, 0.45);
   --focus-ring-strong: 0 0 0 2px rgba(74, 200, 255, 0.3);
+  --focus-outline-color: rgba(74, 200, 255, 0.9);
+  --focus-outline-width: 2px;
 
   /* Button tokens */
   --button-primary-bg: var(--primary);
@@ -104,6 +114,9 @@
   --button-secondary-bg: transparent;
   --button-secondary-text: var(--text-secondary);
   --button-secondary-hover: var(--surface-card-hover);
+  --button-primary-bg-disabled: color-mix(in oklab, var(--primary), white 50%);
+  --button-primary-text-disabled: color-mix(in oklab, var(--button-primary-text), transparent 40%);
+  --button-secondary-text-disabled: color-mix(in oklab, var(--text-secondary), transparent 40%);
 }
 
 /* Dark Theme (default) */
@@ -131,7 +144,6 @@ html.theme-dark {
   --bg-card-elevated: rgba(24, 27, 34, 1.0);
 
   /* Additional card variants for proper hierarchy */
-  --bg-card-elevated: rgba(24, 27, 34, 1.0);
   --bg-card-secondary: rgba(20, 23, 28, 0.9);
   --bg-card-subtle: rgba(16, 18, 22, 0.8);
 
@@ -275,14 +287,14 @@ html.theme-light {
   --surface-card-press: rgba(37, 99, 235, 0.18);
 
   /* Light theme border emphasis */
-  --card-border-strong: 1px solid rgba(37, 99, 235, 0.25);
-  --card-border-focus: 1px solid rgba(37, 99, 235, 0.4);
+  --card-border-strong-color: rgba(37, 99, 235, 0.25);
+  --card-border-focus-color: rgba(37, 99, 235, 0.4);
 
   /* Light theme shadows */
   --shadow-card-base: 0 8px 22px rgba(15, 23, 42, 0.14);
   --shadow-card-hover-base: 0 14px 32px rgba(15, 23, 42, 0.18);
   --shadow-card-strong-base: 0 18px 42px rgba(15, 23, 42, 0.22);
-  --shadow-card-inset-top: inset 0 1px 0 rgba(255, 255, 255, 0.85);
+  --shadow-card-inset-top: inset 0 1px 0 rgba(255, 255, 255, 0.65);
   --shadow-card-inset-bottom: inset 0 -1px 0 rgba(15, 23, 42, 0.08);
   --shadow-card-inset-left: inset 1px 0 0 rgba(255, 255, 255, 0.7);
   --shadow-card-inset-right: inset -1px 0 0 rgba(15, 23, 42, 0.06);
@@ -305,91 +317,91 @@ html.theme-light {
 
 /* Light theme specific: Apply custom gradient to total-card only */
 html.theme-light .total-card {
-  background: var(--gradient-total-card) !important;
-  box-shadow: none !important;
-  border: 2px solid var(--border-profile) !important;
+  background: var(--gradient-total-card);
+  box-shadow: none;
+  border: var(--card-border-width-strong) var(--card-border-style) var(--border-profile);
 }
 
 html.theme-light .total-card:hover {
-  box-shadow: none !important;
+  box-shadow: none;
 }
 
 /* Light theme specific: Better contrast for active tab buttons */
 html.theme-light .tab-btn.active {
-  box-shadow: none !important;
-  border: 2px solid var(--border-profile) !important;
-  background: var(--bg-card-elevated) !important;
+  box-shadow: none;
+  border: var(--card-border-width-strong) var(--card-border-style) var(--border-profile);
+  background: var(--bg-card-elevated);
 }
 
 /* Light theme specific: Better contrast for profile button */
 html.theme-light .user-profile-btn {
-  background: #f8fafc !important;
-  border-color: #e2e8f0 !important;
-  color: var(--text-primary) !important;
+  background: #f8fafc;
+  border: var(--card-border-width) var(--card-border-style) #e2e8f0;
+  color: var(--text-primary);
 }
 
 html.theme-light .user-profile-btn:hover {
-  background: #f1f5f9 !important;
-  border-color: #3B82F6 !important;
-  color: var(--text-primary) !important;
+  background: #f1f5f9;
+  border-color: #3B82F6;
+  color: var(--text-primary);
 }
 
 /* Light theme specific: Remove box shadows and add thicker borders for dashboard elements */
 html.theme-light .header {
-  box-shadow: none !important;
-  border: 2px solid var(--border-profile) !important;
+  box-shadow: none;
+  border: var(--card-border-width-strong) var(--card-border-style) var(--border-profile);
 }
 
 html.theme-light .tab-bar {
-  box-shadow: none !important;
-  border: 2px solid var(--border-profile) !important;
+  box-shadow: none;
+  border: var(--card-border-width-strong) var(--card-border-style) var(--border-profile);
 }
 
 html.theme-light .floating-action-bar {
-  box-shadow: none !important;
-  border: 2px solid var(--border-profile) !important;
+  box-shadow: none;
+  border: var(--card-border-width-strong) var(--card-border-style) var(--border-profile);
 }
 
 html.theme-light .next-shift-card .shift-item.active {
-  box-shadow: none !important;
-  border: 2px solid var(--border-profile) !important;
+  box-shadow: none;
 }
 
 html.theme-light .next-shift-card .shift-item {
-  border: 2px solid var(--border-profile) !important;
+  border: var(--card-border-width-strong) var(--card-border-style) var(--border-profile);
 }
 
 html.theme-light .progress-card {
-  box-shadow: none !important;
-  border: 2px solid var(--border-profile) !important;
+  box-shadow: none;
+  border: var(--card-border-width-strong) var(--card-border-style) var(--border-profile);
 }
 
 html.theme-light .progress-card:hover {
-  box-shadow: none !important;
+  box-shadow: none;
 }
 
 html.theme-light .next-payroll-card .payroll-item {
-  box-shadow: none !important;
-  border: 2px solid var(--border-profile) !important;
+  box-shadow: none;
+  border: var(--card-border-width-strong) var(--card-border-style) var(--border-profile);
 }
 
 
 /* Settings modal card hierarchy for light theme */
 html.theme-light #settingsModal .modal-content {
-  background: var(--bg-card-elevated) !important;
+  background: var(--bg-card-elevated);
 }
 
 html.theme-light #settingsModal .settings-section,
 html.theme-light #settingsModal .form-group {
-  background: var(--bg-card-secondary) !important;
-  border: 1px solid var(--border-light);
+  background: var(--bg-card-secondary);
+  border: var(--card-border);
+  border-color: var(--border-light);
   border-radius: 12px;
   padding: 16px;
 }
 
 html.theme-light #settingsModal .settings-subsection {
-  background: var(--bg-card-subtle) !important;
-  border: 1px solid var(--border);
+  background: var(--bg-card-subtle);
+  border: var(--card-border);
   border-radius: 8px;
   padding: 12px;
 }
@@ -410,6 +422,12 @@ html.theme-switching *,
 html.theme-switching *::before,
 html.theme-switching *::after {
   transition: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition: none !important;
+  }
 }
 
 /* Update color scheme for different themes */
@@ -459,7 +477,12 @@ html.theme-dark {
   padding: var(--space-2);
   border: 2px solid transparent;
   border-radius: var(--border-radius);
-  transition: all var(--speed-normal) var(--ease-default);
+  transition:
+    background-color var(--speed-normal) var(--ease-default),
+    border-color var(--speed-normal) var(--ease-default),
+    color var(--speed-normal) var(--ease-default),
+    box-shadow var(--speed-normal) var(--ease-default),
+    transform var(--speed-normal) var(--ease-default);
 }
 
 .theme-option:hover {
@@ -488,19 +511,25 @@ html.theme-dark {
   border: 2px solid var(--border);
   border-radius: 8px;
   overflow: hidden;
-  transition: all var(--speed-normal) var(--ease-default);
+  transition:
+    background-color var(--speed-normal) var(--ease-default),
+    border-color var(--speed-normal) var(--ease-default),
+    box-shadow var(--speed-normal) var(--ease-default),
+    transform var(--speed-normal) var(--ease-default);
   display: flex;
   flex-direction: column;
 }
 
 .theme-preview-header {
   height: 12px;
-  transition: all var(--speed-normal) var(--ease-default);
+  transition: background-color var(--speed-normal) var(--ease-default),
+              opacity var(--speed-normal) var(--ease-default);
 }
 
 .theme-preview-content {
   flex: 1;
-  transition: all var(--speed-normal) var(--ease-default);
+  transition: background-color var(--speed-normal) var(--ease-default),
+              opacity var(--speed-normal) var(--ease-default);
 }
 
 /* Light theme preview */
@@ -544,7 +573,8 @@ html.theme-dark {
   font-size: var(--text-sm);
   font-weight: var(--font-weight-medium);
   color: var(--text-secondary);
-  transition: all var(--speed-normal) var(--ease-default);
+  transition: color var(--speed-normal) var(--ease-default),
+              font-weight var(--speed-normal) var(--ease-default);
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- swap component focus rules to :focus-visible and tokenized rings across onboarding, legal modal, settings, and shared styles
- consolidate duplicated box-shadows while adding accessible outlines for inputs, month navigation controls, chat, and menus
- extend theme tokens for borders, focus outlines, disabled states, and reduced motion while trimming light-theme !important overrides

## Testing
- not run (CSS updates only)

------
https://chatgpt.com/codex/tasks/task_e_68c92726c43c832f91e24c8335bda33f