### PR TITLE
Normalize custom bonuses to rules format

### DIFF
--- a/app/src/js/appLogic.js
+++ b/app/src/js/appLogic.js
@@ -1,6 +1,7 @@
 import { getUserId } from "/src/lib/auth/getUserId.js";
 import { fetchOnce } from "/src/lib/net/fetchOnce.js";
 import { hasEnterpriseSubscription } from './subscriptionUtils.js';
+import { normalizeUb } from '/src/lib/ubNormalize.js';
 
 
 
@@ -220,6 +221,56 @@ function updateProgressLabelStyling(label, percent) {
     });
 }
 
+const UB_TYPE_TO_DAYS = {
+    weekday: [1, 2, 3, 4, 5],
+    saturday: [6],
+    sunday: [7]
+};
+
+const SHIFT_TYPE_TO_DAYS = {
+    0: UB_TYPE_TO_DAYS.weekday,
+    1: UB_TYPE_TO_DAYS.saturday,
+    2: UB_TYPE_TO_DAYS.sunday
+};
+
+function ubSegmentsForDays(rules, isoDays) {
+    if (!Array.isArray(rules) || !Array.isArray(isoDays) || isoDays.length === 0) return [];
+    const daySet = new Set(isoDays);
+    return rules
+        .filter(rule => Array.isArray(rule?.days) && rule.days.some(day => daySet.has(day)))
+        .map(rule => {
+            const segment = { from: rule.from, to: rule.to };
+            if (rule.percent != null) segment.percent = Number(rule.percent);
+            if (rule.rate != null) segment.rate = Number(rule.rate);
+            return segment;
+        })
+        .filter(rule => typeof rule.from === 'string' && typeof rule.to === 'string');
+}
+
+function ubSegmentsForType(rules, type) {
+    const isoDays = UB_TYPE_TO_DAYS[type] || [];
+    return ubSegmentsForDays(rules, isoDays);
+}
+
+function ubSegmentsForShiftType(rules, shiftType) {
+    const isoDays = SHIFT_TYPE_TO_DAYS[shiftType] || [];
+    return ubSegmentsForDays(rules, isoDays);
+}
+
+function ubRuleHourlyValue(rule, baseWageRate) {
+    if (!rule) return 0;
+    if (rule.rate != null) {
+        const rate = Number(rule.rate);
+        return Number.isNaN(rate) ? 0 : rate;
+    }
+    if (rule.percent != null) {
+        const pct = Number(rule.percent);
+        if (Number.isNaN(pct)) return 0;
+        return baseWageRate * (pct / 100);
+    }
+    return 0;
+}
+
 // Legg til i app-objektet for enkel tilgang fra innstillinger
 if (typeof window !== 'undefined') {
     window.updateProgressBar = updateProgressBar;
@@ -248,17 +299,13 @@ export const app = {
     // Organization settings cache
     orgSettings: { break_policy: 'fixed_0_5_over_5_5h' },
     PRESET_BONUSES: {
-        weekday: [
-            { from: "18:00", to: "21:00", rate: 22 },
-            { from: "21:00", to: "23:59", rate: 45 }
-        ],
-        saturday: [
-            { from: "13:00", to: "15:00", rate: 45 },
-            { from: "15:00", to: "18:00", rate: 55 },
-            { from: "18:00", to: "23:59", rate: 110 }
-        ],
-        sunday: [
-            { from: "00:00", to: "23:59", rate: 115 }
+        rules: [
+            { days: [1, 2, 3, 4, 5], from: "18:00", to: "21:00", rate: 22 },
+            { days: [1, 2, 3, 4, 5], from: "21:00", to: "23:59", rate: 45 },
+            { days: [6], from: "13:00", to: "15:00", rate: 45 },
+            { days: [6], from: "15:00", to: "18:00", rate: 55 },
+            { days: [6], from: "18:00", to: "23:59", rate: 110 },
+            { days: [7], from: "00:00", to: "23:59", rate: 115 }
         ]
     },
     // State
@@ -268,9 +315,10 @@ export const app = {
     currentWageLevel: 1,
     usePreset: true,
     customWage: 200,
-    customBonuses: {}, // Reset to empty - will be loaded from database
+    customBonuses: { rules: [] }, // Reset to empty - will be loaded from database
     // Track current high-level view for modal behavior (dashboard|stats|chatgpt|employees)
     currentView: 'dashboard',
+    customBonusEditingLocked: true,
 
     pauseDeduction: true,
     fullMinuteRange: false, // Setting for using 0-59 minutes instead of 00,15,30,45
@@ -2402,13 +2450,29 @@ export const app = {
 
                 this.currentWageLevel = settings.wage_level || settings.current_wage_level || 1;
 
-                // Ensure customBonuses has proper structure
-                const loadedBonuses = settings.custom_bonuses || {};
-                this.customBonuses = {
-                    weekday: loadedBonuses.weekday || [],
-                    saturday: loadedBonuses.saturday || [],
-                    sunday: loadedBonuses.sunday || []
-                };
+                const normalizedBonuses = normalizeUb(settings.custom_bonuses);
+                if (normalizedBonuses.migrated) {
+                    try {
+                        const column = settings?.id ? 'id' : 'user_id';
+                        const value = settings?.id ?? settings?.user_id;
+                        if (value) {
+                            await window.supa
+                                .from('user_settings')
+                                .update({ custom_bonuses: normalizedBonuses.data })
+                                .eq(column, value);
+                            console.info('UB migrated ->', value);
+                        }
+                    } catch (error) {
+                        console.warn('Failed to persist migrated UB bonuses', error);
+                    }
+                }
+                const normalizedData = normalizedBonuses.data && typeof normalizedBonuses.data === 'object'
+                    ? {
+                        ...normalizedBonuses.data,
+                        rules: Array.isArray(normalizedBonuses.data.rules) ? normalizedBonuses.data.rules : []
+                    }
+                    : { rules: [] };
+                this.customBonuses = normalizedData;
                 // Always set to current month on page load
                 this.currentMonth = new Date().getMonth() + 1;
                 // Load selected year, default to current year if not set
@@ -2467,11 +2531,7 @@ export const app = {
         this.usePreset = true;
         this.customWage = 200;
         this.currentWageLevel = 1;
-        this.customBonuses = {
-            weekday: [],
-            saturday: [],
-            sunday: []
-        };
+        this.customBonuses = { rules: [] };
         this.taxDeductionEnabled = false;
         this.taxPercentage = 0.0;
         this.payrollDay = 15; // Default payroll day (15th of each month)
@@ -2497,14 +2557,10 @@ export const app = {
     // Helper function to test custom bonuses
     setTestCustomBonuses() {
         this.customBonuses = {
-            weekday: [
-                { from: "18:00", to: "22:00", rate: 25 }
-            ],
-            saturday: [
-                { from: "13:00", to: "18:00", rate: 50 }
-            ],
-            sunday: [
-                { from: "00:00", to: "23:59", rate: 100 }
+            rules: [
+                { days: [1, 2, 3, 4, 5], from: "18:00", to: "22:00", rate: 25 },
+                { days: [6], from: "13:00", to: "18:00", rate: 50 },
+                { days: [7], from: "00:00", to: "23:59", rate: 100 }
             ]
         };
         this.populateCustomBonusSlots();
@@ -2823,7 +2879,17 @@ export const app = {
                 this.usePreset = data.usePreset !== false;
                 this.customWage = data.customWage || 200;
                 this.currentWageLevel = data.currentWageLevel || 1;
-                this.customBonuses = data.customBonuses || {};
+                const localNormalized = normalizeUb(data.customBonuses);
+                if (localNormalized.migrated) {
+                    const updated = JSON.stringify({ ...data, customBonuses: localNormalized.data });
+                    localStorage.setItem('lønnsberegnerSettings', updated);
+                }
+                this.customBonuses = localNormalized.data && typeof localNormalized.data === 'object'
+                    ? {
+                        ...localNormalized.data,
+                        rules: Array.isArray(localNormalized.data.rules) ? localNormalized.data.rules : []
+                    }
+                    : { rules: [] };
                 this.currentMonth = new Date().getMonth() + 1; // Always default to current month
                 this.pauseDeduction = data.pauseDeduction !== false; // Legacy setting
                 // Load new break deduction settings from localStorage
@@ -3234,6 +3300,7 @@ export const app = {
 
     populateCustomBonusSlots() {
         const types = ['weekday', 'saturday', 'sunday'];
+        const rules = Array.isArray(this.customBonuses?.rules) ? this.customBonuses.rules : [];
 
         types.forEach(type => {
             const container = document.getElementById(`${type}BonusSlots`);
@@ -3243,134 +3310,37 @@ export const app = {
             }
 
             container.innerHTML = '';
-            const bonuses = (this.customBonuses && this.customBonuses[type]) || [];
+            const segments = ubSegmentsForType(rules, type);
 
-            bonuses.forEach(bonus => {
-                const slot = document.createElement('div');
-                slot.className = 'bonus-slot';
-                slot.innerHTML = `
-                    <div class="bonus-slot-display">
-                        <div class="bonus-time-range">
-                            <span class="bonus-time-text">${bonus.from} - ${bonus.to}</span>
-                        </div>
-                        <div class="bonus-rate-display">
-                            <span class="bonus-rate-text">${bonus.rate} kr/t</span>
-                        </div>
-                    </div>
-                    <div class="bonus-slot-inputs" style="display: none;">
-                        <input type="time" class="form-control" value="${bonus.from}">
-                        <input type="time" class="form-control" value="${bonus.to}">
-                        <input type="number" class="form-control" placeholder="kr/t" value="${bonus.rate}">
-                    </div>
-                    <div class="bonus-slot-buttons">
-                        <button class="btn btn-sm btn-secondary edit-bonus" title="Rediger dette tillegget">Rediger</button>
-                        <button class="btn btn-sm btn-danger remove-bonus" title="Fjern dette tillegget">Fjern</button>
-                        <button class="btn btn-sm btn-primary save-bonus" title="Lagre endringer" style="display: none;">Lagre</button>
-                        <button class="btn btn-sm btn-secondary cancel-bonus" title="Avbryt endringer" style="display: none;">Avbryt</button>
-                    </div>
+            if (!segments.length) {
+                const placeholder = document.createElement('div');
+                placeholder.className = 'supplement-placeholder';
+                placeholder.textContent = 'Ingen tilpassede tillegg';
+                container.appendChild(placeholder);
+                return;
+            }
+
+            segments.forEach(segment => {
+                const row = document.createElement('div');
+                row.className = 'supplement-row is-readonly';
+                const value = segment.rate != null
+                    ? `${Number(segment.rate).toLocaleString('no-NO')} kr/t`
+                    : `${Number(segment.percent).toLocaleString('no-NO')} %`;
+                row.innerHTML = `
+                    <div class="supplement-meta">${segment.from || '--:--'}–${segment.to || '--:--'} • ${value}</div>
                 `;
-
-                // Add event listeners for the new button-based interface
-                const editBtn = slot.querySelector('.edit-bonus');
-                const saveBtn = slot.querySelector('.save-bonus');
-                const cancelBtn = slot.querySelector('.cancel-bonus');
-                const removeBtn = slot.querySelector('.remove-bonus');
-                const displayDiv = slot.querySelector('.bonus-slot-display');
-                const inputsDiv = slot.querySelector('.bonus-slot-inputs');
-                const inputs = slot.querySelectorAll('input');
-                
-                // Store original values for cancel functionality
-                let originalValues = {
-                    from: bonus.from,
-                    to: bonus.to,
-                    rate: bonus.rate
-                };
-
-                // Edit button - switch to edit mode
-                editBtn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    displayDiv.style.display = 'none';
-                    inputsDiv.style.display = 'block';
-                    editBtn.style.display = 'none';
-                    removeBtn.style.display = 'none';
-                    saveBtn.style.display = 'inline-block';
-                    cancelBtn.style.display = 'inline-block';
-                });
-
-                // Save button - save changes and switch back to display mode
-                saveBtn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    const timeInputs = inputsDiv.querySelectorAll('input[type="time"]');
-                    const rateInput = inputsDiv.querySelector('input[type="number"]');
-                    
-                    // Format time inputs
-                    timeInputs.forEach(input => this.formatTimeInput(input));
-                    
-                    // Update display
-                    const timeText = slot.querySelector('.bonus-time-text');
-                    const rateText = slot.querySelector('.bonus-rate-text');
-                    timeText.textContent = `${timeInputs[0].value} - ${timeInputs[1].value}`;
-                    rateText.textContent = `${rateInput.value} kr/t`;
-                    
-                    // Update original values
-                    originalValues = {
-                        from: timeInputs[0].value,
-                        to: timeInputs[1].value,
-                        rate: rateInput.value
-                    };
-                    
-                    // Switch back to display mode
-                    displayDiv.style.display = 'block';
-                    inputsDiv.style.display = 'none';
-                    editBtn.style.display = 'inline-block';
-                    removeBtn.style.display = 'inline-block';
-                    saveBtn.style.display = 'none';
-                    cancelBtn.style.display = 'none';
-                    
-                    // Save to database
-                    this.autoSaveCustomBonuses();
-                });
-
-                // Cancel button - revert changes and switch back to display mode
-                cancelBtn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    const timeInputs = inputsDiv.querySelectorAll('input[type="time"]');
-                    const rateInput = inputsDiv.querySelector('input[type="number"]');
-                    
-                    // Revert to original values
-                    timeInputs[0].value = originalValues.from;
-                    timeInputs[1].value = originalValues.to;
-                    rateInput.value = originalValues.rate;
-                    
-                    // Switch back to display mode
-                    displayDiv.style.display = 'block';
-                    inputsDiv.style.display = 'none';
-                    editBtn.style.display = 'inline-block';
-                    removeBtn.style.display = 'inline-block';
-                    saveBtn.style.display = 'none';
-                    cancelBtn.style.display = 'none';
-                });
-
-                // Remove button - remove the bonus slot
-                removeBtn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    this.removeBonusSlot(removeBtn);
-                });
-
-                // Add time formatting for inputs
-                inputs.forEach(input => {
-                    if (input.type === 'time') {
-                        input.addEventListener('blur', () => {
-                            this.formatTimeInput(input);
-                        });
-                    }
-                });
-
-                container.appendChild(slot);
+                container.appendChild(row);
             });
         });
     },
+    isCustomBonusEditingLocked() {
+        return this.customBonusEditingLocked === true;
+    },
     addBonusSlot(type) {
+        if (this.isCustomBonusEditingLocked()) {
+            console.info('[bonus] Custom bonus editing is disabled during migration');
+            return;
+        }
         const container = document.getElementById(`${type}BonusSlots`);
         if (!container) {
             console.error(`Container ${type}BonusSlots not found`);
@@ -3428,6 +3398,10 @@ export const app = {
 
     },
     removeBonusSlot(button) {
+        if (this.isCustomBonusEditingLocked()) {
+            console.info('[bonus] Custom bonus editing is disabled during migration');
+            return;
+        }
         // Ask confirmation before removing a supplement slot
         if (!confirm('Er du sikker på at du vil fjerne dette tillegget?')) return;
         const el = button.closest('.bonus-slot');
@@ -3440,6 +3414,10 @@ export const app = {
 
     // Insert or update a single bonus slot and persist
     async upsertBonusSlot(type, indexOrNull, slot) {
+        if (this.isCustomBonusEditingLocked()) {
+            console.info('[bonus] Custom bonus editing is disabled during migration');
+            return false;
+        }
         try {
             const timeToMinutes = (t) => {
                 if (!t || typeof t !== 'string') return null;
@@ -3504,6 +3482,7 @@ export const app = {
 
     // Auto-save custom bonuses with debouncing to avoid too many saves
     autoSaveCustomBonuses() {
+        if (this.isCustomBonusEditingLocked()) return;
         if (!this.usePreset) {
             // Clear existing timeout to prevent memory leaks
             if (this.autoSaveTimeout) {
@@ -4202,17 +4181,9 @@ export const app = {
         return this.getCurrentWageRate();
     },
     getCurrentBonuses() {
-        if (this.usePreset) {
-            return this.PRESET_BONUSES;
-        } else {
-            // Ensure customBonuses has the expected structure
-            const bonuses = this.customBonuses || {};
-            return {
-                weekday: bonuses.weekday || [],
-                saturday: bonuses.saturday || [],
-                sunday: bonuses.sunday || []
-            };
-        }
+        const source = this.usePreset ? this.PRESET_BONUSES : (this.customBonuses || { rules: [] });
+        const rules = Array.isArray(source.rules) ? source.rules : [];
+        return { rules };
     },
     // Master refresh function for global UI updates after /chat responses
     refreshUI(shifts, showLoading = false) {
@@ -6296,15 +6267,14 @@ export const app = {
             !!shift?.employee
         );
         const bonuses = isEmployeeShift ? this.PRESET_BONUSES : this.getCurrentBonuses();
-        const bonusType = shift.type === 0 ? 'weekday' : (shift.type === 1 ? 'saturday' : 'sunday');
-        const bonusSegments = bonuses[bonusType] || [];
+        const bonusSegments = ubSegmentsForShiftType(bonuses.rules, shift.type);
 
         // Calculate base earnings so far
         const baseEarned = hoursWorked * wageRate;
 
         // Calculate bonus earnings so far - include seconds for real-time updates
         const currentTimeStr = `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}:${now.getSeconds().toString().padStart(2, '0')}`;
-        const bonusEarned = this.calculateBonusWithSeconds(shift.startTime, currentTimeStr, bonusSegments);
+        const bonusEarned = this.calculateBonusWithSeconds(shift.startTime, currentTimeStr, bonusSegments, wageRate);
 
         return {
             totalHours: hoursWorked,
@@ -7395,8 +7365,7 @@ export const app = {
         let bonusBreakdownHtml = '';
         if (calc.bonus > 0) {
             const bonuses = this.getCurrentBonuses();
-            const bonusType = shift.type === 0 ? 'weekday' : (shift.type === 1 ? 'saturday' : 'sunday');
-            const bonusSegments = bonuses[bonusType] || [];
+            const bonusSegments = ubSegmentsForShiftType(bonuses.rules, shift.type);
             
             // Calculate the same adjusted end time as in calculateShift for consistency
             const startMinutes = this.timeToMinutes(shift.startTime);
@@ -7415,7 +7384,7 @@ export const app = {
                 adjustedEndTime = `${String(endHour).padStart(2,'0')}:${(adjustedEndMinutes % 60).toString().padStart(2,'0')}`;
             }
             
-            const bonusBreakdown = this.calculateBonusBreakdown(shift.startTime, adjustedEndTime, bonusSegments);
+            const bonusBreakdown = this.calculateBonusBreakdown(shift.startTime, adjustedEndTime, bonusSegments, shiftWageRate);
             
             if (bonusBreakdown.breakdown.length > 0) {
                 bonusBreakdownHtml = `
@@ -8635,8 +8604,7 @@ export const app = {
             }
 
             baseWage = paidHours * wageRate;
-            const bonusType = shift.type === 0 ? 'weekday' : (shift.type === 1 ? 'saturday' : 'sunday');
-            const bonusSegments = bonuses[bonusType] || [];
+            const bonusSegments = ubSegmentsForShiftType(bonuses.rules, shift.type);
 
             // Recreate the end time after any pause deduction or midnight handling
             // so we can reuse the same format when calculating bonuses
@@ -8646,7 +8614,8 @@ export const app = {
             bonus = this.calculateBonus(
                 shift.startTime,
                 endTimeStr,
-                bonusSegments
+                bonusSegments,
+                wageRate
             );
 
             // Debug logging for traditional calculations
@@ -8775,18 +8744,18 @@ export const app = {
     // Calculate wage periods for break deduction analysis with cross-midnight and weekday/weekend handling
     calculateWagePeriods(shift, baseWageRate, bonuses, startMinutes, endMinutes) {
         const periods = [];
+        const rules = Array.isArray(bonuses?.rules) ? bonuses.rules : [];
 
-        const dayToBonusKey = (dow) => (dow === 0 ? 'sunday' : (dow === 6 ? 'saturday' : 'weekday'));
+        const dayToIsoDay = (dow) => (dow === 0 ? 7 : dow);
 
-        // Build periods inside [dayStart, dayEnd] for a given day's bonus key
-        const buildDay = (dayStart, dayEnd, bonusKey) => {
+        const buildDay = (dayStart, dayEnd, isoDay) => {
             if (dayEnd <= dayStart) return;
-            const applicable = bonuses[bonusKey] || [];
+            const applicable = ubSegmentsForDays(rules, [isoDay]);
             let segments = [{ start: dayStart, end: dayEnd, bonuses: [] }];
             for (const b of applicable) {
                 const s = this.timeToMinutes(b.from);
                 let e = this.timeToMinutes(b.to);
-                if (e <= s) e += 24 * 60; // wrap
+                if (e <= s) e += 24 * 60;
                 const os = Math.max(dayStart, s);
                 const oe = Math.min(dayEnd, e);
                 if (oe <= os) continue;
@@ -8804,7 +8773,7 @@ export const app = {
             for (const seg of segments) {
                 const h = (seg.end - seg.start) / 60;
                 if (h <= 0) continue;
-                const bonusRate = seg.bonuses.reduce((sum, x) => sum + x.rate, 0);
+                const bonusRate = seg.bonuses.reduce((sum, x) => sum + ubRuleHourlyValue(x, baseWageRate), 0);
                 periods.push({
                     startMinutes: seg.start,
                     endMinutes: seg.end,
@@ -8813,22 +8782,22 @@ export const app = {
                     bonusRate,
                     totalRate: baseWageRate + bonusRate,
                     type: bonusRate > 0 ? 'bonus' : 'base',
-                    bonuses: seg.bonuses
+                    bonuses: seg.bonuses.map(slot => ({ ...slot }))
                 });
             }
         };
 
-        // Determine day-of-week from shift.date when available; otherwise use type fallback
         const startDow = (shift?.date instanceof Date)
             ? shift.date.getDay()
             : (shift?.type === 2 ? 0 : (shift?.type === 1 ? 6 : 1));
+        const startIso = dayToIsoDay(startDow);
 
         const firstEnd = Math.min(endMinutes, 24 * 60);
-        buildDay(startMinutes, firstEnd, dayToBonusKey(startDow));
+        buildDay(startMinutes, firstEnd, startIso);
 
         if (endMinutes > 24 * 60) {
             const nextDow = (startDow + 1) % 7;
-            buildDay(0, endMinutes - 24 * 60, dayToBonusKey(nextDow));
+            buildDay(0, endMinutes - 24 * 60, dayToIsoDay(nextDow));
         }
 
         return periods;
@@ -9201,7 +9170,7 @@ export const app = {
         return hours * 3600 + minutes * 60 + seconds;
     },
 
-    calculateBonus(startTime, endTime, bonusSegments) {
+    calculateBonus(startTime, endTime, bonusSegments, baseWageRate = 0) {
         let totalBonus = 0;
         const startMinutes = this.timeToMinutes(startTime);
         let endMinutes = this.timeToMinutes(endTime);
@@ -9217,13 +9186,13 @@ export const app = {
                 segEnd += 24 * 60;
             }
             const overlap = this.calculateOverlap(startMinutes, endMinutes, segStart, segEnd);
-            totalBonus += (overlap / 60) * segment.rate;
+            totalBonus += (overlap / 60) * ubRuleHourlyValue(segment, baseWageRate);
         }
         return totalBonus;
     },
 
     // Calculate detailed bonus breakdown for display in shift details
-    calculateBonusBreakdown(startTime, endTime, bonusSegments) {
+    calculateBonusBreakdown(startTime, endTime, bonusSegments, baseWageRate = 0) {
         const startMinutes = this.timeToMinutes(startTime);
         let endMinutes = this.timeToMinutes(endTime);
         
@@ -9245,16 +9214,17 @@ export const app = {
             const overlap = this.calculateOverlap(startMinutes, endMinutes, segStart, segEnd);
             if (overlap > 0) {
                 const hours = overlap / 60;
-                const amount = hours * segment.rate;
+                const rate = ubRuleHourlyValue(segment, baseWageRate);
+                const amount = hours * rate;
                 totalBonus += amount;
-                
+
                 // Format the time period display
                 const displayFrom = segment.from;
                 const displayTo = segment.to === '23:59' ? '24:00' : segment.to;
-                
+
                 breakdown.push({
                     period: `${displayFrom} - ${displayTo}`,
-                    rate: segment.rate,
+                    rate,
                     hours: hours,
                     amount: amount
                 });
@@ -9268,7 +9238,7 @@ export const app = {
     },
 
     // New function for second-precise bonus calculations
-    calculateBonusWithSeconds(startTime, endTime, bonusSegments) {
+    calculateBonusWithSeconds(startTime, endTime, bonusSegments, baseWageRate = 0) {
         let totalBonus = 0;
         const startSeconds = this.timeToSeconds(startTime);
         let endSeconds = this.timeToSeconds(endTime);
@@ -9285,7 +9255,7 @@ export const app = {
                 segEnd += 24 * 3600; // Add 24 hours in seconds
             }
             const overlap = this.calculateOverlap(startSeconds, endSeconds, segStart, segEnd);
-            totalBonus += (overlap / 3600) * segment.rate; // Convert seconds to hours
+            totalBonus += (overlap / 3600) * ubRuleHourlyValue(segment, baseWageRate); // Convert seconds to hours
         }
         return totalBonus;
     },
@@ -9974,6 +9944,9 @@ export const app = {
 
     // Capture custom bonuses from UI form elements
     captureCustomBonusesFromUI() {
+        if (this.isCustomBonusEditingLocked()) {
+            return { rules: [] };
+        }
         const capturedBonuses = {};
         const types = ['weekday', 'saturday', 'sunday'];
 
@@ -10006,6 +9979,10 @@ export const app = {
     },
 
     async saveCustomBonuses() {
+        if (this.isCustomBonusEditingLocked()) {
+            console.info('[bonus] Custom bonus editing is disabled during migration');
+            return;
+        }
 
         // Use the new improved capture system
         const capturedBonuses = this.captureCustomBonusesFromUI();
@@ -10053,6 +10030,9 @@ export const app = {
 
     // Silent version of saveCustomBonuses for auto-save (no alerts or status messages)
     async saveCustomBonusesSilent() {
+        if (this.isCustomBonusEditingLocked()) {
+            return;
+        }
         try {
 
             // Use the new improved capture system

--- a/app/src/lib/ubNormalize.js
+++ b/app/src/lib/ubNormalize.js
@@ -1,0 +1,32 @@
+export function normalizeUb(data){
+  if (!data || typeof data !== 'object') return { data, migrated:false };
+  if (Array.isArray(data.rules)) return { data, migrated:false };
+
+  const map = [
+    ['weekday',[1,2,3,4,5]],
+    ['saturday',[6]],
+    ['sunday',[7]],
+  ];
+
+  const rules = [];
+  let touched = false;
+
+  for (const [key, days] of map){
+    const arr = Array.isArray(data?.[key]) ? data[key] : [];
+    if (!arr.length) continue;
+    touched = true;
+    for (const x of arr){
+      const rule = { days, from:x.from, to:x.to };
+      if (x.percent != null) rule.percent = Number(x.percent);
+      else if (x.rate != null) rule.rate = Number(x.rate);
+      else continue;
+      rules.push(rule);
+    }
+  }
+
+  if (!touched) return { data, migrated:false };
+
+  const next = { ...data, rules };
+  delete next.weekday; delete next.saturday; delete next.sunday;
+  return { data: next, migrated:true };
+}

--- a/server/server.js
+++ b/server/server.js
@@ -2331,16 +2331,90 @@ function getTariffRate(level) {
 }
 
 const PRESET_BONUSES = {
-  weekday: [
-    { from: '18:00', to: '06:00', rate: 15.5 }
-  ],
-  saturday: [
-    { from: '00:00', to: '24:00', rate: 15.5 }
-  ],
-  sunday: [
-    { from: '00:00', to: '24:00', rate: 31.0 }
+  rules: [
+    { days: [1, 2, 3, 4, 5], from: '18:00', to: '06:00', rate: 15.5 },
+    { days: [6], from: '00:00', to: '24:00', rate: 15.5 },
+    { days: [7], from: '00:00', to: '24:00', rate: 31.0 }
   ]
 };
+
+function normalizeUb(data) {
+  if (!data || typeof data !== 'object') return { data, migrated: false };
+  if (Array.isArray(data.rules)) return { data, migrated: false };
+
+  const map = [
+    ['weekday', [1, 2, 3, 4, 5]],
+    ['saturday', [6]],
+    ['sunday', [7]]
+  ];
+
+  const rules = [];
+  let touched = false;
+
+  for (const [key, days] of map) {
+    const arr = Array.isArray(data?.[key]) ? data[key] : [];
+    if (!arr.length) continue;
+    touched = true;
+    for (const x of arr) {
+      const rule = { days, from: x.from, to: x.to };
+      if (x.percent != null) rule.percent = Number(x.percent);
+      else if (x.rate != null) rule.rate = Number(x.rate);
+      else continue;
+      rules.push(rule);
+    }
+  }
+
+  if (!touched) return { data, migrated: false };
+
+  const next = { ...data, rules };
+  delete next.weekday; delete next.saturday; delete next.sunday;
+  return { data: next, migrated: true };
+}
+
+const UB_TYPE_TO_DAYS = {
+  weekday: [1, 2, 3, 4, 5],
+  saturday: [6],
+  sunday: [7]
+};
+
+const SHIFT_TYPE_TO_DAYS = {
+  0: UB_TYPE_TO_DAYS.weekday,
+  1: UB_TYPE_TO_DAYS.saturday,
+  2: UB_TYPE_TO_DAYS.sunday
+};
+
+function ubSegmentsForDays(rules, isoDays) {
+  if (!Array.isArray(rules) || !Array.isArray(isoDays) || isoDays.length === 0) return [];
+  const daySet = new Set(isoDays);
+  return rules
+    .filter(rule => Array.isArray(rule?.days) && rule.days.some(day => daySet.has(day)))
+    .map(rule => {
+      const segment = { from: rule.from, to: rule.to };
+      if (rule.percent != null) segment.percent = Number(rule.percent);
+      if (rule.rate != null) segment.rate = Number(rule.rate);
+      return segment;
+    })
+    .filter(rule => typeof rule.from === 'string' && typeof rule.to === 'string');
+}
+
+function ubSegmentsForShiftType(rules, shiftType) {
+  const isoDays = SHIFT_TYPE_TO_DAYS[shiftType] || [];
+  return ubSegmentsForDays(rules, isoDays);
+}
+
+function ubRuleHourlyValue(rule, baseWageRate) {
+  if (!rule) return 0;
+  if (rule.rate != null) {
+    const rate = Number(rule.rate);
+    return Number.isNaN(rate) ? 0 : rate;
+  }
+  if (rule.percent != null) {
+    const pct = Number(rule.percent);
+    if (Number.isNaN(pct)) return 0;
+    return baseWageRate * (pct / 100);
+  }
+  return 0;
+}
 
 function timeToMinutes(timeStr) {
   const [hours, minutes] = timeStr.split(':').map(Number);
@@ -2532,7 +2606,7 @@ function calculateOverlap(start1, end1, start2, end2) {
   return Math.max(0, overlapEnd - overlapStart);
 }
 
-function calculateBonus(startTime, endTime, bonusSegments) {
+function calculateBonus(startTime, endTime, bonusSegments, baseWageRate = 0) {
   let totalBonus = 0;
   const startMinutes = timeToMinutes(startTime);
   let endMinutes = timeToMinutes(endTime);
@@ -2549,7 +2623,7 @@ function calculateBonus(startTime, endTime, bonusSegments) {
       segEnd += 24 * 60;
     }
     const overlap = calculateOverlap(startMinutes, endMinutes, segStart, segEnd);
-    totalBonus += (overlap / 60) * segment.rate;
+    totalBonus += (overlap / 60) * ubRuleHourlyValue(segment, baseWageRate);
   }
   return totalBonus;
 }
@@ -2666,105 +2740,81 @@ function calculateLegalBreakDeduction(shift, userSettings, wageRate, bonuses) {
 // Calculate wage periods for break deduction analysis (non-overlapping periods)
 function calculateWagePeriods(shift, baseWageRate, bonuses, startMinutes, endMinutes) {
   const periods = [];
-  const dayOfWeek = new Date(shift.shift_date).getDay();
+  const rules = Array.isArray(bonuses?.rules) ? bonuses.rules : [];
+  const shiftDate = shift?.shift_date ? new Date(shift.shift_date) : null;
+  const startDow = shiftDate ? shiftDate.getDay() : (shift?.shift_type === 2 ? 0 : (shift?.shift_type === 1 ? 6 : 1));
+  const dayToIso = (dow) => (dow === 0 ? 7 : dow);
 
-  // Determine which bonus segments apply
-  let applicableBonuses = [];
-  if (dayOfWeek === 0) { // Sunday
-    applicableBonuses = bonuses.sunday || [];
-  } else if (dayOfWeek === 6) { // Saturday
-    applicableBonuses = bonuses.saturday || [];
-  } else { // Weekday
-    applicableBonuses = bonuses.weekday || [];
-  }
-
-  // Create time segments with their applicable bonuses
-  const timeSegments = [];
-
-  // Start with the entire shift as base rate
-  timeSegments.push({
-    start: startMinutes,
-    end: endMinutes,
-    bonuses: []
-  });
-
-  // Apply each bonus to overlapping segments
-  for (const bonus of applicableBonuses) {
-    const bonusStart = timeToMinutes(bonus.from);
-    let bonusEnd = timeToMinutes(bonus.to);
-    if (bonusEnd <= bonusStart) {
-      bonusEnd += 24 * 60;
-    }
-
-    const overlapStart = Math.max(startMinutes, bonusStart);
-    const overlapEnd = Math.min(endMinutes, bonusEnd);
-
-    if (overlapEnd > overlapStart) {
-      // Split existing segments to accommodate this bonus
-      const newSegments = [];
-
-      for (const segment of timeSegments) {
-        if (segment.end <= overlapStart || segment.start >= overlapEnd) {
-          // No overlap - keep segment as is
-          newSegments.push(segment);
-        } else {
-          // There's overlap - split the segment
-
-          // Part before bonus (if any)
-          if (segment.start < overlapStart) {
-            newSegments.push({
-              start: segment.start,
-              end: overlapStart,
-              bonuses: [...segment.bonuses]
-            });
-          }
-
-          // Overlapping part with bonus added
-          const overlapSegmentStart = Math.max(segment.start, overlapStart);
-          const overlapSegmentEnd = Math.min(segment.end, overlapEnd);
-          if (overlapSegmentEnd > overlapSegmentStart) {
-            newSegments.push({
-              start: overlapSegmentStart,
-              end: overlapSegmentEnd,
-              bonuses: [...segment.bonuses, bonus]
-            });
-          }
-
-          // Part after bonus (if any)
-          if (segment.end > overlapEnd) {
-            newSegments.push({
-              start: overlapEnd,
-              end: segment.end,
-              bonuses: [...segment.bonuses]
-            });
-          }
-        }
+  const buildDay = (dayStart, dayEnd, isoDay) => {
+    if (dayEnd <= dayStart) return;
+    const applicable = ubSegmentsForDays(rules, [isoDay]);
+    let segments = [{ start: dayStart, end: dayEnd, bonuses: [] }];
+    for (const bonus of applicable) {
+      const bonusStart = timeToMinutes(bonus.from);
+      let bonusEnd = timeToMinutes(bonus.to);
+      if (bonusEnd <= bonusStart) {
+        bonusEnd += 24 * 60;
       }
 
-      timeSegments.length = 0;
-      timeSegments.push(...newSegments);
+      const overlapStart = Math.max(dayStart, bonusStart);
+      const overlapEnd = Math.min(dayEnd, bonusEnd);
+
+      if (overlapEnd > overlapStart) {
+        const newSegments = [];
+        for (const segment of segments) {
+          if (segment.end <= overlapStart || segment.start >= overlapEnd) {
+            newSegments.push(segment);
+          } else {
+            if (segment.start < overlapStart) {
+              newSegments.push({ start: segment.start, end: overlapStart, bonuses: [...segment.bonuses] });
+            }
+            const overlapSegmentStart = Math.max(segment.start, overlapStart);
+            const overlapSegmentEnd = Math.min(segment.end, overlapEnd);
+            if (overlapSegmentEnd > overlapSegmentStart) {
+              newSegments.push({
+                start: overlapSegmentStart,
+                end: overlapSegmentEnd,
+                bonuses: [...segment.bonuses, bonus]
+              });
+            }
+            if (segment.end > overlapEnd) {
+              newSegments.push({ start: overlapEnd, end: segment.end, bonuses: [...segment.bonuses] });
+            }
+          }
+        }
+        segments = newSegments;
+      }
     }
-  }
 
-  // Convert time segments to wage periods
-  for (const segment of timeSegments) {
-    const durationHours = (segment.end - segment.start) / 60;
-    const totalBonusRate = segment.bonuses.reduce((sum, bonus) => sum + bonus.rate, 0);
+    for (const segment of segments) {
+      const durationMinutes = segment.end - segment.start;
+      if (durationMinutes <= 0) continue;
+      const durationHours = durationMinutes / 60;
+      const bonusRate = segment.bonuses.reduce((sum, slot) => sum + ubRuleHourlyValue(slot, baseWageRate), 0);
+      periods.push({
+        startMinutes: segment.start,
+        endMinutes: segment.end,
+        durationHours,
+        wageRate: baseWageRate,
+        bonusRate,
+        totalRate: baseWageRate + bonusRate,
+        type: bonusRate > 0 ? 'bonus' : 'base',
+        bonuses: segment.bonuses.map(slot => ({ ...slot }))
+      });
+    }
+  };
 
-    periods.push({
-      startMinutes: segment.start,
-      endMinutes: segment.end,
-      durationHours: durationHours,
-      wageRate: baseWageRate,
-      bonusRate: totalBonusRate,
-      totalRate: baseWageRate + totalBonusRate,
-      type: totalBonusRate > 0 ? 'bonus' : 'base',
-      bonuses: segment.bonuses
-    });
+  const firstEnd = Math.min(endMinutes, 24 * 60);
+  buildDay(startMinutes, firstEnd, dayToIso(startDow));
+
+  if (endMinutes > 24 * 60) {
+    const nextDow = (startDow + 1) % 7;
+    buildDay(0, endMinutes - 24 * 60, dayToIso(nextDow));
   }
 
   return periods;
 }
+
 
 // Apply proportional break deduction across all wage periods
 function applyProportionalDeduction(wagePeriods, deductionHours, startMinutes, endMinutes) {
@@ -2906,6 +2956,31 @@ async function getUserSettings(user_id) {
   if (error && error.code !== 'PGRST116') {
     console.error('Error fetching user settings:', error);
     return null;
+  }
+
+  if (settings && 'custom_bonuses' in settings) {
+    const normalized = normalizeUb(settings.custom_bonuses);
+    if (normalized.migrated) {
+      try {
+        const column = settings?.id ? 'id' : 'user_id';
+        const value = settings?.id ?? user_id;
+        if (value) {
+          await supabase
+            .from('user_settings')
+            .update({ custom_bonuses: normalized.data })
+            .eq(column, value);
+          console.info('UB migrated ->', value);
+        }
+      } catch (migrationError) {
+        console.warn('Failed to persist migrated UB bonuses', migrationError);
+      }
+    }
+    settings.custom_bonuses = normalized.data && typeof normalized.data === 'object'
+      ? {
+          ...normalized.data,
+          rules: Array.isArray(normalized.data.rules) ? normalized.data.rules : []
+        }
+      : { rules: [] };
   }
 
   return settings;
@@ -3053,11 +3128,7 @@ function calculateShiftEarnings(shift, userSettings) {
     : (userSettings?.custom_wage || 200);
 
   // Get bonuses
-  const bonuses = usePreset ? PRESET_BONUSES : (userSettings?.custom_bonuses || {
-    weekday: [],
-    saturday: [],
-    sunday: []
-  });
+  const bonuses = usePreset ? PRESET_BONUSES : (userSettings?.custom_bonuses || { rules: [] });
 
   // Apply legal break deduction system
   const breakResult = calculateLegalBreakDeduction(shift, userSettings, wageRate, bonuses);
@@ -3085,14 +3156,13 @@ function calculateShiftEarnings(shift, userSettings) {
 
     baseWage = paidHours * wageRate;
 
-    const bonusType = shift.shift_type === 0 ? 'weekday' : (shift.shift_type === 1 ? 'saturday' : 'sunday');
-    const bonusSegments = bonuses[bonusType] || [];
+    const bonusSegments = ubSegmentsForShiftType(bonuses.rules, shift.shift_type);
 
     // Calculate end time after adjustments
     const endHour = Math.floor(adjustedEndMinutes / 60) % 24;
     const endTimeStr = `${String(endHour).padStart(2,'0')}:${(adjustedEndMinutes % 60).toString().padStart(2,'0')}`;
 
-    bonus = calculateBonus(shift.start_time, endTimeStr, bonusSegments);
+    bonus = calculateBonus(shift.start_time, endTimeStr, bonusSegments, wageRate);
 
     // Debug logging for traditional calculations
     if (durationHours > 5.5) {


### PR DESCRIPTION
## Summary
- add a shared `normalizeUb` helper and use it when loading user settings so legacy weekday/weekend bonus data is rewritten to the new `rules[]` structure
- update client wage calculations and displays to rely on rule-based bonus segments and temporarily lock the advanced bonus editor UI during migration
- migrate onboarding and server payroll logic to read and write bonus rules, updating existing rows in Supabase on first read

## Testing
- `npm --workspace app run build` *(fails: missing optional dependency @supabase/supabase-js)*
- `npm --workspace server run test` *(fails: missing optional dependency dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68cb465272c0832fa3a977dd7363339f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified, rules-based bonus model replaces per-day bonuses.
  * Automatic migration of legacy bonuses on load with migrated data persisted (backend and client).
  * Wage calculations now support both fixed-rate and percent-based rules and accept base-wage context for percent rules.
  * Onboarding prefill/save updated to use the new rules format; UI defaults adjusted.

* **Refactor**
  * Settings bonus editor simplified: existing bonuses shown but editing disabled with a migration notice and edit lock.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->