### PR TITLE
Fix shifts nav add button pointer events

### DIFF
--- a/app/src/css/style.css
+++ b/app/src/css/style.css
@@ -16990,7 +16990,7 @@ body.chatbox-view .chatbox-container {
 
 /* 2) Exactly one visible element per state for the shared name */
 .is-hidden { visibility: hidden; pointer-events: none; }
-body.view-shifts .nav-add        { visibility: hidden; pointer-events: none; }
+body.view-shifts .nav-add:not(.nav-add-small)        { visibility: hidden; pointer-events: none; }
 body.view-shifts .nav-add-small  { visibility: visible; }
 body:not(.view-shifts) .nav-add  { visibility: visible; }
 body:not(.view-shifts) .nav-add-small { visibility: hidden; pointer-events: none; }


### PR DESCRIPTION
## Summary
- prevent the shifts-specific bottom nav from disabling pointer events on the small add button so it can navigate to shiftAdd

## Testing
- npm --workspace app run build *(fails: missing optional dependency @supabase/supabase-js in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc15c03e14832fb16b6f592d7b028b