### PR TITLE
Refine floating month navigation spacing

### DIFF
--- a/app/src/css/style.css
+++ b/app/src/css/style.css
@@ -11454,30 +11454,47 @@ input[type="file"].form-control:focus-visible {
   z-index: 200;
 }
 
-/* Dashboard month picker - positioned 6px above nav bar, 2/3 width */
+/* Shared spacing for floating controls that sit above the bottom navigation */
+:root {
+  --floating-over-nav-gap: clamp(12px, 2.5vw, 20px);
+}
+
+/* Dashboard month picker - positioned above nav bar with responsive gap */
 .dashboard-month-container {
   position: fixed;
-  bottom: calc(env(safe-area-inset-bottom, 16px) + 78px); /* 6px above nav bar (16px + 56px + 6px) */
+  bottom: calc(
+    env(safe-area-inset-bottom, 16px)
+    + var(--nav-h, 84px)
+    + var(--floating-over-nav-gap, clamp(12px, 2.5vw, 20px))
+  );
   left: 50%;
   transform: translateX(-50%);
   width: min(450px, calc(100% - 32px)); /* ~2/3 of navbar width, max viewport minus padding */
   z-index: 300;
 }
 
-/* Statistics page month picker - positioned 6px above nav bar, 2/3 width */
+/* Statistics page month picker - positioned above nav bar with responsive gap */
 .statistics-month-container {
   position: fixed;
-  bottom: calc(env(safe-area-inset-bottom, 16px) + 78px); /* 6px above nav bar (16px + 56px + 6px) */
+  bottom: calc(
+    env(safe-area-inset-bottom, 16px)
+    + var(--nav-h, 84px)
+    + var(--floating-over-nav-gap, clamp(12px, 2.5vw, 20px))
+  );
   left: 50%;
   transform: translateX(-50%);
   width: min(450px, calc(100% - 32px)); /* ~2/3 of navbar width, max viewport minus padding */
   z-index: 300;
 }
 
-/* Shifts page tab bar container - positioned 6px above nav bar, full nav width */
+/* Shifts page tab bar container - positioned above nav bar with responsive gap */
 .shifts-page .tab-bar-container {
   position: fixed;
-  bottom: calc(env(safe-area-inset-bottom, 16px) + 78px); /* 6px above nav bar (16px + 56px + 6px) */
+  bottom: calc(
+    env(safe-area-inset-bottom, 16px)
+    + var(--nav-h, 84px)
+    + var(--floating-over-nav-gap, clamp(12px, 2.5vw, 20px))
+  );
   left: 50%;
   transform: translateX(-50%);
   width: min(680px, calc(100% - 32px)); /* Match nav bar width */

--- a/app/src/js/app.js
+++ b/app/src/js/app.js
@@ -45,6 +45,40 @@ function detectiOSPWA() {
   }
 }
 
+function updateFloatingNavOffsets() {
+  try {
+    const docEl = document?.documentElement;
+    if (!docEl) return;
+
+    const bottomNav = document.querySelector('.bottom-nav');
+    if (!bottomNav) {
+      docEl.style.setProperty('--nav-h', '0px');
+      docEl.style.setProperty('--floating-over-nav-gap', '0px');
+      return;
+    }
+
+    const navStyles = window.getComputedStyle(bottomNav);
+    const isHidden = navStyles.display === 'none' || navStyles.visibility === 'hidden';
+
+    if (isHidden) {
+      docEl.style.setProperty('--nav-h', '0px');
+      docEl.style.setProperty('--floating-over-nav-gap', '0px');
+      return;
+    }
+
+    const navHeight = bottomNav.offsetHeight + (parseFloat(navStyles.marginBottom) || 0);
+    docEl.style.setProperty('--nav-h', `${Math.max(0, navHeight)}px`);
+    // Restore default responsive gap when nav is visible
+    docEl.style.removeProperty('--floating-over-nav-gap');
+  } catch (error) {
+    console.warn('Failed to update floating nav offsets:', error);
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.updateFloatingNavOffsets = updateFloatingNavOffsets;
+}
+
 function setThemeColor() {
   // This function is now handled by the theme manager
   // setThemeColor is no longer needed as theme manager handles meta theme colors
@@ -68,14 +102,17 @@ setAppHeight();
 setThemeColor();
 detectiOSPWA();
 handleResponsiveMonthNavigation(); // Initial call
+updateFloatingNavOffsets();
 window.addEventListener('resize', () => {
   setAppHeight();
   handleResponsiveMonthNavigation();
+  updateFloatingNavOffsets();
 });
 if (window.visualViewport) {
   window.visualViewport.addEventListener('resize', () => {
     setAppHeight();
     handleResponsiveMonthNavigation();
+    updateFloatingNavOffsets();
   });
 }
 
@@ -84,6 +121,7 @@ window.addEventListener('orientationchange', () => {
   setTimeout(() => {
     setAppHeight();
     handleResponsiveMonthNavigation(); // Handle month navigation positioning after orientation change
+    updateFloatingNavOffsets();
   }, 100); // Delay to ensure orientation change is complete
 });
 
@@ -93,6 +131,7 @@ window.addEventListener('scroll', () => {
   clearTimeout(scrollTimeout);
   scrollTimeout = setTimeout(() => {
     setAppHeight();
+    updateFloatingNavOffsets();
   }, 50); // Debounced scroll handler
 });
 

--- a/app/src/router.js
+++ b/app/src/router.js
@@ -335,6 +335,14 @@ export async function render() {
     } else {
       bottomNav.style.display = '';
     }
+
+    if (typeof window !== 'undefined' && typeof window.updateFloatingNavOffsets === 'function') {
+      try {
+        window.updateFloatingNavOffsets();
+      } catch (error) {
+        console.warn('Failed to sync floating nav offsets after route change:', error);
+      }
+    }
   }
 
   // Tag body/html during onboarding for scoped CSS


### PR DESCRIPTION
## Summary
- use a responsive gap variable for floating month pickers and the shifts view toggle, factoring in the measured nav height
- add a runtime helper that updates the nav height CSS variables across resize/orientation/scroll events and expose it globally
- resync floating control offsets whenever the router hides or shows the bottom navigation

## Testing
- npm --workspace app run build *(fails: vite cannot resolve @supabase/supabase-js in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf65b092ec832f9d04c59d0f127a76