### PR TITLE
Revamp statistics dashboard page

### DIFF
--- a/app/src/css/style.css
+++ b/app/src/css/style.css
@@ -11502,25 +11502,504 @@ input[type="file"].form-control:focus-visible {
   min-width: 0; /* Allow shrinking if needed */
 }
 
-/* Statistics page styling - width constraints to match other pages */
+/* Statistics page styling */
 .statistics-page {
-  max-width: 800px;
+  max-width: 1120px;
   margin: 0 auto;
-  padding: 0 max(16px, env(safe-area-inset-left)) 0 max(16px, env(safe-area-inset-right));
+  padding: clamp(24px, 6vw, 48px) clamp(16px, 5vw, 56px) calc(96px + var(--safe-area-inset-bottom));
   min-height: 100vh;
-  padding-bottom: calc(64px + var(--safe-area-inset-bottom) + 70px); /* Space for nav + month picker */
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 5vw, 48px);
 }
 
-.statistics-header {
-  padding: var(--space-6) 0 var(--space-4) 0;
+.statistics-hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-hero);
+  background: linear-gradient(135deg, rgba(10, 24, 38, 0.95), rgba(12, 32, 52, 0.85));
+  border: 1px solid rgba(74, 200, 255, 0.25);
+  box-shadow: var(--shadow-card);
+  padding: clamp(24px, 5vw, 48px);
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: clamp(16px, 4vw, 32px);
+}
+
+.statistics-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(74, 200, 255, 0.45), transparent 55%);
+  opacity: 0.65;
+}
+
+.statistics-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.statistics-hero__text {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.statistics-hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.statistics-hero__title {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: var(--font-weight-extrabold);
+  color: var(--text-primary);
+}
+
+.statistics-hero__subtitle {
+  margin: 0;
+  font-size: var(--text-base);
+  color: var(--text-secondary);
+  max-width: 40ch;
+}
+
+.statistics-hero__subtitle span {
+  font-weight: var(--font-weight-semibold);
+}
+
+.statistics-hero__status {
+  margin: auto 0 0;
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.statistics-hero__status time {
+  font-variant-numeric: tabular-nums;
+}
+
+.statistics-hero__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 16px;
+}
+
+.statistics-month {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(74, 200, 255, 0.35);
+  background: rgba(8, 22, 34, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(74, 200, 255, 0.2);
+}
+
+.month-display {
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  min-width: 150px;
   text-align: center;
 }
 
-.statistics-header .page-title {
-  font-size: var(--text-2xl);
+.month-nav-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  background: rgba(74, 200, 255, 0.12);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: all var(--speed-normal) var(--ease-default);
+}
+
+.month-nav-button svg {
+  width: 18px;
+  height: 18px;
+}
+
+.month-nav-button:hover {
+  background: rgba(74, 200, 255, 0.2);
+  border-color: rgba(74, 200, 255, 0.4);
+}
+
+.month-nav-button:focus-visible {
+  outline: var(--focus-outline-width) solid var(--focus-outline-color);
+  outline-offset: 3px;
+  background: rgba(74, 200, 255, 0.25);
+}
+
+.statistics-hero__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: var(--radius-pill);
+  background: rgba(74, 200, 255, 0.16);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  box-shadow: inset 0 0 0 1px rgba(74, 200, 255, 0.3);
+}
+
+.statistics-hero__pill svg {
+  width: 18px;
+  height: 18px;
+}
+
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: clamp(12px, 2vw, 16px);
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+}
+
+.section-heading p {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.statistics-overview,
+.statistics-insights {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 24px);
+}
+
+.statistics-overview__grid,
+.statistics-insights__grid {
+  display: grid;
+  gap: clamp(16px, 3vw, 24px);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.finance-card {
+  position: relative;
+  background: var(--surface-card);
+  border: 1px solid rgba(74, 200, 255, 0.1);
+  border-radius: var(--radius-card);
+  padding: clamp(20px, 3vw, 28px);
+  box-shadow: var(--shadow-card-lite);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition: transform var(--speed-normal) var(--ease-default),
+    box-shadow var(--speed-normal) var(--ease-default);
+}
+
+.finance-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-card);
+}
+
+.finance-card:focus-visible {
+  outline: var(--focus-outline-width) solid var(--focus-outline-color);
+  outline-offset: 3px;
+  box-shadow: var(--shadow-card), var(--focus-ring);
+}
+
+.finance-card--primary {
+  background: var(--surface-card-elevated);
+  border: 1px solid rgba(74, 200, 255, 0.3);
+  box-shadow: var(--shadow-card);
+}
+
+.finance-card--muted {
+  background: var(--surface-card-subtle);
+}
+
+.finance-card--goal {
+  background: linear-gradient(135deg, rgba(22, 80, 120, 0.75), rgba(12, 44, 68, 0.85));
+  border: 1px solid rgba(74, 200, 255, 0.35);
+  color: var(--text-primary);
+}
+
+.finance-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.finance-card__eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+}
+
+.finance-card__title {
+  margin: 4px 0 0;
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+}
+
+.finance-card__metric {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.75rem);
   font-weight: var(--font-weight-bold);
   color: var(--text-primary);
+}
+
+.finance-card__caption {
   margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.finance-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-pill);
+  background: rgba(74, 200, 255, 0.14);
+  color: var(--primary);
+  box-shadow: inset 0 0 0 1px rgba(74, 200, 255, 0.3);
+}
+
+.finance-card__icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.statistics-overview .total-card {
+  align-items: flex-start;
+  text-align: left;
+  gap: 12px;
+  cursor: default;
+  padding: clamp(24px, 4vw, 36px);
+}
+
+.statistics-overview .total-card::before {
+  opacity: 0.45;
+}
+
+.statistics-overview .total-card .finance-card__header {
+  width: 100%;
+}
+
+.statistics-overview .total-card #totalAmount {
+  font-size: clamp(2.2rem, 5vw, 3.2rem);
+}
+
+.statistics-overview .total-card .total-secondary-info {
+  width: 100%;
+}
+
+.statistics-overview .total-card .total-label {
+  color: var(--text-tertiary);
+}
+
+.statistics-chart {
+  background: var(--surface-card);
+  border: 1px solid rgba(74, 200, 255, 0.12);
+  border-radius: var(--radius-card);
+  padding: clamp(20px, 4vw, 32px);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 24px);
+}
+
+.statistics-chart .weekly-hours-chart-card {
+  background: transparent;
+  border: none;
+  padding: 0;
+  box-shadow: none;
+}
+
+.statistics-chart .chart-cards-container {
+  display: flex;
+  gap: clamp(16px, 4vw, 24px);
+  flex-wrap: wrap;
+}
+
+.statistics-chart .chart-visualization-card {
+  flex: 1 1 320px;
+  min-width: 0;
+}
+
+.statistics-chart .chart-hours-section {
+  flex: 0 0 240px;
+  align-self: stretch;
+  gap: 12px;
+  position: relative;
+}
+
+.statistics-chart .chart-hours-section .chart-hours-value-card,
+.statistics-chart .chart-hours-section .chart-shifts-count-card {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(74, 200, 255, 0.2);
+}
+
+.statistics-chart .chart-hours-section .chart-hours-value-card:hover,
+.statistics-chart .chart-hours-section .chart-hours-value-card:focus-visible,
+.statistics-chart .chart-hours-section .chart-shifts-count-card:hover,
+.statistics-chart .chart-hours-section .chart-shifts-count-card:focus-visible {
+  border-color: rgba(74, 200, 255, 0.4);
+}
+
+.statistics-chart .chart-progress-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(74, 200, 255, 0.08);
+  border-radius: var(--radius-pill);
+  padding: 8px 16px;
+  border: 1px solid rgba(74, 200, 255, 0.15);
+}
+
+.statistics-chart .chart-progress-fill {
+  border-radius: var(--radius-pill);
+  background: var(--gradient-primary);
+}
+
+.statistics-chart .chart-progress-label {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.insight-card {
+  background: var(--surface-card-subtle);
+  border: 1px solid rgba(74, 200, 255, 0.12);
+  border-radius: var(--radius-card);
+  padding: clamp(20px, 3vw, 28px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: var(--shadow-card-lite);
+  transition: transform var(--speed-normal) var(--ease-default),
+    box-shadow var(--speed-normal) var(--ease-default);
+}
+
+.insight-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-card);
+}
+
+.insight-card__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.insight-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-pill);
+  background: rgba(74, 200, 255, 0.12);
+  color: var(--primary);
+}
+
+.insight-card__icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.insight-card__eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.insight-card__metric {
+  margin: 0;
+  font-size: clamp(1.5rem, 3.5vw, 2.4rem);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+}
+
+.insight-card__caption {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.insight-card--accent {
+  background: linear-gradient(135deg, rgba(58, 110, 165, 0.75), rgba(22, 48, 78, 0.85));
+  border: 1px solid rgba(74, 200, 255, 0.4);
+  box-shadow: var(--shadow-card);
+}
+
+@media (max-width: 960px) {
+  .statistics-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .statistics-hero__meta {
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 768px) {
+  .statistics-page {
+    padding: clamp(16px, 5vw, 24px);
+    padding-bottom: calc(96px + var(--safe-area-inset-bottom));
+  }
+
+  .statistics-hero {
+    padding: clamp(20px, 6vw, 28px);
+  }
+
+  .statistics-hero__status {
+    margin-top: 16px;
+  }
+
+  .statistics-month {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .statistics-hero__pill {
+    margin-top: 12px;
+  }
+
+  .statistics-chart .chart-cards-container {
+    flex-direction: column;
+  }
+
+  .statistics-chart .chart-hours-section {
+    flex: 1 1 auto;
+    width: 100%;
+    flex-direction: row;
+  }
+}
+
+@media (max-width: 600px) {
+  .statistics-overview__grid,
+  .statistics-insights__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .finance-card__metric {
+    font-size: clamp(1.8rem, 7vw, 2.4rem);
+  }
 }
 
 /* Tab bar styling as independent pill-shaped element */

--- a/app/src/pages/statistikk.js
+++ b/app/src/pages/statistikk.js
@@ -1,62 +1,220 @@
 export function renderStatistikk() {
     return `
         <div class="statistics-page">
-            <div class="statistics-header">
-                <h1 class="page-title">Statistikk</h1>
-            </div>
+            <header class="statistics-hero" role="banner">
+                <div class="statistics-hero__text">
+                    <span class="statistics-hero__eyebrow">Innsikt</span>
+                    <h1 class="statistics-hero__title">Statistikk</h1>
+                    <p class="statistics-hero__subtitle">
+                        Følg inntektene dine og finn trender i <span data-month-copy data-month-fallback="denne måneden">denne måneden</span>.
+                    </p>
+                    <p class="statistics-hero__status" aria-live="polite">
+                        Sist oppdatert <time id="lastUpdatedTime">--:--</time>
+                    </p>
+                </div>
+                <div class="statistics-hero__meta">
+                    <div class="statistics-month" role="group" aria-label="Velg måned">
+                        <button type="button" class="month-nav-button" aria-label="Forrige måned" onclick="navigateStatisticsMonth('prev')">
+                            <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="15 18 9 12 15 6"></polyline>
+                            </svg>
+                        </button>
+                        <div class="month-display" id="currentMonthStatistics" aria-live="polite" aria-atomic="true">--</div>
+                        <button type="button" class="month-nav-button" aria-label="Neste måned" onclick="navigateStatisticsMonth('next')">
+                            <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="9 6 15 12 9 18"></polyline>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="statistics-hero__pill">
+                        <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M3 17c3-6 9-10 18-10"></path>
+                            <polyline points="19 5 21 7 19 9"></polyline>
+                        </svg>
+                        <span>Oppsummering</span>
+                    </div>
+                </div>
+            </header>
 
-            <div class="statistics-content">
+            <section class="statistics-overview" aria-labelledby="statisticsOverviewHeading">
+                <div class="section-heading">
+                    <h2 id="statisticsOverviewHeading">Månedsoversikt</h2>
+                    <p>Høydepunkter for <span id="overviewMonthName">denne måneden</span>.</p>
+                </div>
+                <div class="statistics-overview__grid">
+                    <article class="finance-card finance-card--primary total-card" tabindex="0">
+                        <div class="finance-card__header">
+                            <div>
+                                <p class="finance-card__eyebrow">Utbetalt</p>
+                                <h3 class="finance-card__title">Denne måneden</h3>
+                            </div>
+                            <span class="finance-card__icon" aria-hidden="true">
+                                <svg focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                                    <rect x="3" y="6" width="18" height="12" rx="2"></rect>
+                                    <line x1="3" y1="10" x2="21" y2="10"></line>
+                                    <circle cx="12" cy="13" r="2.5"></circle>
+                                </svg>
+                            </span>
+                        </div>
+                        <div class="finance-card__metric" id="totalAmount" aria-live="polite">0 kr</div>
+                        <p class="finance-card__caption total-label">Denne måneden</p>
+                        <div class="total-secondary-info" id="totalSecondaryInfo" aria-live="polite">
+                            <div class="secondary-info-content">
+                                <span class="bonus-amount">0 kr</span>
+                                <span class="before-tax-text">før skatt</span>
+                            </div>
+                        </div>
+                    </article>
+
+                    <article class="finance-card finance-card--muted" aria-live="polite">
+                        <div class="finance-card__header">
+                            <p class="finance-card__eyebrow">Timer jobbet</p>
+                            <span class="finance-card__icon" aria-hidden="true">
+                                <svg focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                                    <circle cx="12" cy="12" r="8"></circle>
+                                    <polyline points="12 8 12 12 15 13"></polyline>
+                                </svg>
+                            </span>
+                        </div>
+                        <div class="finance-card__metric" id="totalHoursDisplay">0</div>
+                        <p class="finance-card__caption" id="totalHoursSubtext">Timer registrert</p>
+                    </article>
+
+                    <article class="finance-card finance-card--muted" aria-live="polite">
+                        <div class="finance-card__header">
+                            <p class="finance-card__eyebrow">Antall vakter</p>
+                            <span class="finance-card__icon" aria-hidden="true">
+                                <svg focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                                    <rect x="3" y="4" width="18" height="18" rx="3"></rect>
+                                    <path d="M16 2v4"></path>
+                                    <path d="M8 2v4"></path>
+                                    <line x1="3" y1="10" x2="21" y2="10"></line>
+                                </svg>
+                            </span>
+                        </div>
+                        <div class="finance-card__metric" id="shiftCountDisplay">0</div>
+                        <p class="finance-card__caption" id="shiftCountSubtext">Registrerte vakter</p>
+                    </article>
+
+                    <article class="finance-card finance-card--goal" aria-live="polite">
+                        <div class="finance-card__header">
+                            <p class="finance-card__eyebrow">Måloppnåelse</p>
+                            <span class="finance-card__icon" aria-hidden="true">
+                                <svg focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                                    <circle cx="12" cy="12" r="9"></circle>
+                                    <polyline points="12 7 12 12 15 15"></polyline>
+                                </svg>
+                            </span>
+                        </div>
+                        <div class="finance-card__metric" id="goalProgressValue">0%</div>
+                        <p class="finance-card__caption" id="goalProgressMeta">0 kr av 0 kr</p>
+                    </article>
+                </div>
+            </section>
+
+            <section class="statistics-chart" aria-labelledby="workloadHeading">
+                <div class="section-heading">
+                    <h2 id="workloadHeading">Ukentlig oversikt</h2>
+                    <p>Se hvordan timene fordeler seg gjennom måneden.</p>
+                </div>
                 <div class="weekly-hours-chart-card" id="weeklyHoursChart">
                     <div class="chart-cards-container">
-                        <!-- Bar Chart Card -->
-                        <div class="chart-visualization-card">
+                        <div class="chart-visualization-card" role="presentation">
                             <div class="chart-container">
                                 <div class="chart-content">
-                                    <div class="chart-bars" id="chartBars">
-                                        <!-- Bars will be populated dynamically -->
-                                    </div>
+                                    <div class="chart-bars" id="chartBars" role="list" aria-label="Timer per uke"></div>
                                 </div>
-                                <div class="chart-labels" id="chartLabels">
-                                    <!-- Week labels will be populated dynamically -->
-                                </div>
+                                <div class="chart-labels" id="chartLabels" aria-hidden="true"></div>
                             </div>
-                            <div class="chart-tooltip" id="chartTooltip">
+                            <div class="chart-tooltip" id="chartTooltip" role="status" aria-live="polite">
                                 <span id="tooltipContent"></span>
                             </div>
                         </div>
 
-                        <!-- Hours Section - Two Stacked Cards -->
-                        <div class="chart-hours-section">
-                            <!-- Total Hours Card -->
-                            <div class="chart-hours-value-card">
+                        <div class="chart-hours-section chart-stats-section" aria-label="Detaljer for valgt periode">
+                            <div class="chart-hours-value-card" role="button" tabindex="0">
                                 <div class="hours-value-content">
                                     <div class="hours-value-number" id="totalHours">0</div>
                                     <div class="hours-value-label">timer</div>
                                 </div>
                             </div>
 
-                            <!-- Shift Count Card -->
-                            <div class="chart-shifts-count-card">
+                            <div class="chart-shifts-count-card" role="button" tabindex="0">
                                 <div class="shifts-count-content">
                                     <div class="shifts-count-number" id="shiftCount">0</div>
                                     <div class="shifts-count-label">vakter</div>
                                 </div>
                             </div>
 
-                            <!-- Custom tooltip for wage cards -->
-                            <div class="wage-card-tooltip" id="wageCardTooltip">
+                            <div class="wage-card-tooltip" id="wageCardTooltip" role="tooltip">
                                 <span id="wageTooltipContent"></span>
                             </div>
                         </div>
                     </div>
 
-                    <!-- Progress bar positioned below both cards -->
-                    <div class="chart-progress-bar" title="Månedlig mål fremdrift">
+                    <div class="chart-progress-bar" title="Fremdrift mot månedlig mål">
                         <div class="chart-progress-fill loading" style="width: 0%"></div>
                         <span class="chart-progress-label">0 % av 0 kr</span>
+                        <span class="sr-only" id="chartProgressAccessible"></span>
                     </div>
                 </div>
-            </div>
+            </section>
+
+            <section class="statistics-insights" aria-labelledby="statisticsInsightsHeading">
+                <div class="section-heading">
+                    <h2 id="statisticsInsightsHeading">Lønnsinnsikt</h2>
+                    <p>Oppdag hvordan vaktene påvirker inntektene dine.</p>
+                </div>
+                <div class="statistics-insights__grid">
+                    <article class="insight-card" aria-live="polite">
+                        <div class="insight-card__header">
+                            <span class="insight-card__icon" aria-hidden="true">
+                                <svg focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M12 3v3"></path>
+                                    <path d="M12 18v3"></path>
+                                    <path d="M4.93 4.93l2.12 2.12"></path>
+                                    <path d="M16.95 16.95l2.12 2.12"></path>
+                                    <path d="M21 12h-3"></path>
+                                    <path d="M6 12H3"></path>
+                                    <circle cx="12" cy="12" r="4"></circle>
+                                </svg>
+                            </span>
+                            <p class="insight-card__eyebrow">Snitt per time</p>
+                        </div>
+                        <div class="insight-card__metric" id="averageHourlyRate">—</div>
+                        <p class="insight-card__caption" id="averageHourlyMeta">Basert på registrerte timer</p>
+                    </article>
+
+                    <article class="insight-card" aria-live="polite">
+                        <div class="insight-card__header">
+                            <span class="insight-card__icon" aria-hidden="true">
+                                <svg focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M4 9v11a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1V9"></path>
+                                    <path d="M12 3l8 6H4Z"></path>
+                                    <path d="M9 14h6"></path>
+                                    <path d="M9 18h3"></path>
+                                </svg>
+                            </span>
+                            <p class="insight-card__eyebrow">Tillegg og bonuser</p>
+                        </div>
+                        <div class="insight-card__metric" id="totalBonusAmount">—</div>
+                        <p class="insight-card__caption">Totalt ekstra denne måneden</p>
+                    </article>
+
+                    <article class="insight-card insight-card--accent" aria-live="polite">
+                        <div class="insight-card__header">
+                            <span class="insight-card__icon" aria-hidden="true">
+                                <svg focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                                    <polygon points="12 2 15 9 22 9 17 14 19 21 12 17 5 21 7 14 2 9 9 9"></polygon>
+                                </svg>
+                            </span>
+                            <p class="insight-card__eyebrow">Beste vakt</p>
+                        </div>
+                        <div class="insight-card__metric" id="bestShiftValue">—</div>
+                        <p class="insight-card__caption" id="bestShiftMeta">Ingen registrerte vakter ennå</p>
+                    </article>
+                </div>
+            </section>
         </div>
     `;
 }
@@ -67,6 +225,8 @@ export function afterMountStatistikk() {
         // Set current view for the app
         window.app.currentView = 'statistikk';
 
+        attachStatisticsEnhancer();
+
         // Initialize month display
         updateStatisticsMonthDisplay();
 
@@ -75,6 +235,8 @@ export function afterMountStatistikk() {
 
         // Set up chart interactions and force chart rendering
         setupChartInteractions();
+
+        updateFinanceHighlights();
 
         // Additional initialization to ensure proper display
         setTimeout(() => {
@@ -88,6 +250,7 @@ export function afterMountStatistikk() {
 
             // Re-run chart interactions setup in case new bars were created
             setupChartInteractions();
+            updateFinanceHighlights();
         }, 200);
     }
 }
@@ -113,6 +276,8 @@ function updateStatisticsMonthDisplay() {
         if (monthDisplay && window.app.getCurrentMonthDisplay) {
             monthDisplay.textContent = window.app.getCurrentMonthDisplay();
         }
+
+        updateMonthCopy();
     }
 }
 
@@ -127,6 +292,8 @@ function loadStatisticsData() {
         if (window.app.updateWeeklyChart) {
             window.app.updateWeeklyChart();
         }
+
+        updateFinanceHighlights();
     }
 }
 
@@ -161,6 +328,327 @@ function setupChartInteractions() {
             }
         }, 100);
     }
+
+    const statCards = document.querySelectorAll('.chart-hours-value-card, .chart-shifts-count-card');
+    statCards.forEach(card => {
+        if (card.dataset.keyboardBound === 'true') {
+            return;
+        }
+
+        card.setAttribute('role', card.getAttribute('role') || 'button');
+        card.setAttribute('tabindex', card.getAttribute('tabindex') || '0');
+
+        card.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                card.click();
+            }
+        });
+
+        card.dataset.keyboardBound = 'true';
+    });
+}
+
+function attachStatisticsEnhancer() {
+    if (!window.app || window.app.__statisticsEnhancerInstalled || window.app.__statisticsEnhancerPending) {
+        return;
+    }
+
+    const installWrapper = () => {
+        if (typeof window.app.updateStats !== 'function') {
+            return false;
+        }
+
+        const originalUpdateStats = window.app.updateStats.bind(window.app);
+        window.app.updateStats = function enhancedUpdateStats(...args) {
+            const result = originalUpdateStats(...args);
+
+            if (window.app?.currentView === 'statistikk') {
+                requestAnimationFrame(() => {
+                    updateFinanceHighlights();
+                });
+            }
+
+            return result;
+        };
+
+        window.app.__statisticsEnhancerInstalled = true;
+        window.app.__statisticsEnhancerPending = false;
+        return true;
+    };
+
+    if (installWrapper()) {
+        return;
+    }
+
+    window.app.__statisticsEnhancerPending = true;
+    let attempts = 0;
+    const interval = setInterval(() => {
+        if (installWrapper() || attempts > 20) {
+            clearInterval(interval);
+            window.app.__statisticsEnhancerPending = false;
+        }
+        attempts += 1;
+    }, 100);
+}
+
+function updateFinanceHighlights() {
+    if (typeof window === 'undefined' || !window.app) {
+        return;
+    }
+
+    const app = window.app;
+    const month = app.currentMonth;
+    const year = app.currentYear;
+    const shifts = Array.isArray(app.shifts) ? app.shifts : [];
+
+    const monthShifts = shifts.filter(shift => {
+        if (!shift || !shift.date) {
+            return false;
+        }
+
+        const date = shift.date instanceof Date ? shift.date : new Date(shift.date);
+        if (Number.isNaN(date.getTime())) {
+            return false;
+        }
+
+        return date.getMonth() === (month - 1) && date.getFullYear() === year;
+    });
+
+    let totalHours = 0;
+    let totalBase = 0;
+    let totalBonus = 0;
+    let bestShift = null;
+
+    monthShifts.forEach(shift => {
+        if (typeof app.calculateShift !== 'function') {
+            return;
+        }
+
+        const calculation = app.calculateShift.call(app, shift);
+        if (!calculation) {
+            return;
+        }
+
+        totalHours += calculation.hours || 0;
+        totalBase += calculation.baseWage || 0;
+        totalBonus += calculation.bonus || 0;
+
+        const shiftTotal = (calculation.baseWage || 0) + (calculation.bonus || 0);
+        if (!bestShift || shiftTotal > bestShift.total) {
+            bestShift = {
+                total: shiftTotal,
+                hours: calculation.hours || 0,
+                shift
+            };
+        }
+    });
+
+    const totalAmount = totalBase + totalBonus;
+    const taxFactor = app.taxDeductionEnabled ? 1 - ((app.taxPercentage || 0) / 100) : 1;
+    const displayAmount = totalAmount * taxFactor;
+
+    const formatter = typeof app.formatCurrency === 'function'
+        ? app.formatCurrency.bind(app)
+        : (value) => new Intl.NumberFormat('no-NO', { style: 'currency', currency: 'NOK', maximumFractionDigits: 0 }).format(value || 0);
+
+    const hoursDisplay = document.getElementById('totalHoursDisplay');
+    if (hoursDisplay) {
+        hoursDisplay.textContent = formatHoursValue(totalHours);
+    }
+
+    const hoursSubtext = document.getElementById('totalHoursSubtext');
+    if (hoursSubtext) {
+        const monthName = getDisplayMonthName();
+        if (totalHours > 0 && monthName) {
+            hoursSubtext.textContent = `Timer registrert i ${monthName.toLowerCase()}`;
+        } else if (monthName) {
+            hoursSubtext.textContent = `Ingen registrerte timer for ${monthName.toLowerCase()}`;
+        } else {
+            hoursSubtext.textContent = totalHours > 0 ? 'Timer registrert denne perioden' : 'Ingen timer registrert';
+        }
+    }
+
+    const shiftDisplay = document.getElementById('shiftCountDisplay');
+    if (shiftDisplay) {
+        shiftDisplay.textContent = monthShifts.length.toLocaleString('no-NO');
+    }
+
+    const shiftSubtext = document.getElementById('shiftCountSubtext');
+    if (shiftSubtext) {
+        const monthName = getDisplayMonthName();
+        if (monthShifts.length > 0 && monthName) {
+            const suffix = monthShifts.length === 1 ? 'vakt' : 'vakter';
+            shiftSubtext.textContent = `${suffix} i ${monthName.toLowerCase()}`;
+        } else if (monthName) {
+            shiftSubtext.textContent = `Ingen vakter registrert i ${monthName.toLowerCase()}`;
+        } else {
+            shiftSubtext.textContent = 'Ingen vakter registrert';
+        }
+    }
+
+    const averageRateEl = document.getElementById('averageHourlyRate');
+    if (averageRateEl) {
+        if (totalHours > 0) {
+            averageRateEl.textContent = formatter(totalAmount / totalHours);
+        } else {
+            averageRateEl.textContent = '—';
+        }
+    }
+
+    const averageMetaEl = document.getElementById('averageHourlyMeta');
+    if (averageMetaEl) {
+        if (totalHours > 0) {
+            const suffix = monthShifts.length === 1 ? 'vakt' : 'vakter';
+            averageMetaEl.textContent = `${formatHoursValue(totalHours)} timer fordelt på ${monthShifts.length} ${suffix}`;
+        } else {
+            averageMetaEl.textContent = 'Registrer vakter for å se snittlønn per time';
+        }
+    }
+
+    const bonusEl = document.getElementById('totalBonusAmount');
+    if (bonusEl) {
+        bonusEl.textContent = totalBonus > 0 ? formatter(totalBonus) : '—';
+    }
+
+    const bestShiftValueEl = document.getElementById('bestShiftValue');
+    const bestShiftMetaEl = document.getElementById('bestShiftMeta');
+    if (bestShiftValueEl && bestShiftMetaEl) {
+        if (bestShift) {
+            bestShiftValueEl.textContent = formatter(bestShift.total);
+
+            const date = bestShift.shift.date instanceof Date ? bestShift.shift.date : new Date(bestShift.shift.date);
+            const hasValidDate = !Number.isNaN(date.getTime());
+            const formattedDate = hasValidDate ? date.toLocaleDateString('no-NO', { day: '2-digit', month: 'short' }) : '';
+            const timeRange = bestShift.shift.startTime && bestShift.shift.endTime
+                ? `${bestShift.shift.startTime}–${bestShift.shift.endTime}`
+                : '';
+            const hoursText = `${formatHoursValue(bestShift.hours)} timer`;
+
+            const details = [formattedDate, timeRange, hoursText].filter(Boolean).join(' • ');
+            bestShiftMetaEl.textContent = details || 'Detaljer utilgjengelig';
+        } else {
+            bestShiftValueEl.textContent = '—';
+            bestShiftMetaEl.textContent = 'Ingen registrerte vakter ennå';
+        }
+    }
+
+    const monthNameEl = document.getElementById('overviewMonthName');
+    if (monthNameEl) {
+        const monthName = getDisplayMonthName();
+        monthNameEl.textContent = monthName || 'denne måneden';
+    }
+
+    const monthlyGoal = getMonthlyGoalValue();
+    const progressValueEl = document.getElementById('goalProgressValue');
+    const progressMetaEl = document.getElementById('goalProgressMeta');
+    if (progressValueEl && progressMetaEl) {
+        if (monthlyGoal > 0) {
+            const percentRaw = (displayAmount / monthlyGoal) * 100;
+            const percentValue = Math.max(0, percentRaw);
+            const percentFormatted = percentValue > 0 && percentValue < 10
+                ? percentValue.toFixed(1)
+                : Math.round(percentValue);
+
+            progressValueEl.textContent = `${Math.min(percentFormatted, 999)}%`;
+            progressMetaEl.textContent = `${formatter(displayAmount)} av ${formatter(monthlyGoal)}`;
+        } else {
+            progressValueEl.textContent = '—';
+            progressMetaEl.textContent = 'Sett et mål for å følge fremdrift';
+        }
+    }
+
+    const progressBar = document.querySelector('.chart-progress-bar');
+    if (progressBar) {
+        if (monthlyGoal > 0) {
+            const percentRaw = (displayAmount / monthlyGoal) * 100;
+            const percentValue = Math.max(0, Math.min(percentRaw, 100));
+
+            progressBar.setAttribute('role', 'progressbar');
+            progressBar.setAttribute('aria-valuemin', '0');
+            progressBar.setAttribute('aria-valuemax', monthlyGoal.toString());
+            progressBar.setAttribute('aria-valuenow', Math.round(Math.min(displayAmount, monthlyGoal)).toString());
+            progressBar.setAttribute('aria-valuetext', `${percentValue.toFixed(percentValue < 10 ? 1 : 0)}% av ${formatter(monthlyGoal)}`);
+        } else {
+            progressBar.removeAttribute('role');
+            progressBar.removeAttribute('aria-valuemin');
+            progressBar.removeAttribute('aria-valuemax');
+            progressBar.removeAttribute('aria-valuenow');
+            progressBar.removeAttribute('aria-valuetext');
+        }
+    }
+
+    const progressAccessible = document.getElementById('chartProgressAccessible');
+    if (progressAccessible) {
+        if (monthlyGoal > 0) {
+            const percentRaw = (displayAmount / monthlyGoal) * 100;
+            const percentValue = Math.max(0, percentRaw);
+            const percentFormatted = percentValue > 0 && percentValue < 10
+                ? percentValue.toFixed(1)
+                : Math.round(percentValue);
+
+            progressAccessible.textContent = `${percentFormatted}% av ${formatter(monthlyGoal)}`;
+        } else {
+            progressAccessible.textContent = 'Ingen mål definert for denne måneden.';
+        }
+    }
+
+    updateMonthCopy();
+}
+
+function updateMonthCopy() {
+    if (typeof window === 'undefined' || !window.app) {
+        return;
+    }
+
+    const monthName = getDisplayMonthName();
+    document.querySelectorAll('[data-month-copy]').forEach(element => {
+        const fallback = element.getAttribute('data-month-fallback') || 'denne måneden';
+        element.textContent = monthName || fallback;
+    });
+}
+
+function getDisplayMonthName() {
+    if (typeof window === 'undefined' || !window.app) {
+        return '';
+    }
+
+    const months = Array.isArray(window.app.MONTHS) ? window.app.MONTHS : [];
+    const monthIndex = (window.app.currentMonth || 1) - 1;
+    const baseName = months[monthIndex];
+
+    if (!baseName) {
+        return '';
+    }
+
+    return baseName.charAt(0).toUpperCase() + baseName.slice(1);
+}
+
+function getMonthlyGoalValue() {
+    if (typeof window === 'undefined') {
+        return 20000;
+    }
+
+    const appGoal = window.app?.monthlyGoal;
+    if (typeof appGoal === 'number' && !Number.isNaN(appGoal)) {
+        return appGoal;
+    }
+
+    const stored = localStorage.getItem('monthlyGoal');
+    const parsed = stored ? parseInt(stored, 10) : NaN;
+    return Number.isFinite(parsed) ? parsed : 20000;
+}
+
+function formatHoursValue(value) {
+    if (!Number.isFinite(value) || value === 0) {
+        return '0';
+    }
+
+    const hasDecimals = Math.abs(value % 1) > 0.01;
+    return value.toLocaleString('no-NO', {
+        minimumFractionDigits: hasDecimals ? 1 : 0,
+        maximumFractionDigits: hasDecimals ? 1 : 0
+    });
 }
 
 // Make month navigation functions available globally

--- a/package-lock.json
+++ b/package-lock.json
@@ -4283,7 +4283,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -7677,27 +7677,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/openai": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.18.1.tgz",
-      "integrity": "sha512-iXSOfLlOL+jgnFr5CGrB2SEZw5C92o1nrFW2SasoAXj4QxGhfeJPgg8zkX+vaCfX80cT6CWjgaGnq7z9XzbyRw==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/own-keys": {
@@ -11671,9 +11650,7 @@
         "express": "^5.1.0",
         "jose": "^6.0.12",
         "morgan": "^1.10.0",
-        "openai": "^5.12.0",
-        "stripe": "^18.4.0",
-        "ws": "^8.18.3"
+        "stripe": "^18.4.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.10"


### PR DESCRIPTION
## Summary
- redesign the statistics route with a finance inspired hero, overview cards, weekly chart container and insight widgets
- compute monthly highlights, goal progress and best shift details on mount while keeping the existing chart logic in sync
- layer new finance themed styles that emphasize accessibility, responsive layout and keyboard friendly interactions

## Testing
- npm --workspace app run build

------
https://chatgpt.com/codex/tasks/task_e_68cf6575bdfc832f92372915ef694a60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Redesigned Statistics page with a rich hero, overview, insights, and weekly chart widgets.
  - Dynamic month navigation (prev/next) with unified month display.
  - Real-time finance highlights: totals, hours, shifts, bonuses, best shift, averages, and progress toward monthly goal.
  - Enhanced accessibility with improved keyboard interactions and screen reader announcements.

- Style
  - Wider layout (max width increased to 1120px) with a new card- and grid-based design.
  - Cohesive visuals: refined radii, borders, shadows, and typography.
  - Responsive adjustments across breakpoints for better mobile and tablet experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->