### PR TITLE
Fix statistikk month display and summary navigation

### DIFF
--- a/app/src/js/appLogic.js
+++ b/app/src/js/appLogic.js
@@ -4404,6 +4404,20 @@ export const app = {
 
         // console.log('Payroll card updated via existing updateNextPayrollCard function');
     },
+    getCurrentMonthDisplay() {
+        const months = Array.isArray(this.MONTHS) ? this.MONTHS : [];
+        const monthIndex = (this.currentMonth || 1) - 1;
+        const baseName = months[monthIndex];
+
+        if (!baseName) {
+            return '--';
+        }
+
+        const capitalizedName = baseName.charAt(0).toUpperCase() + baseName.slice(1);
+        const year = Number.isFinite(this.currentYear) ? this.currentYear : new Date().getFullYear();
+
+        return `${capitalizedName} ${year}`;
+    },
     updateHeader() {
         const monthName = this.MONTHS[this.currentMonth - 1].charAt(0).toUpperCase() + this.MONTHS[this.currentMonth - 1].slice(1);
 


### PR DESCRIPTION
## Summary
- expose a reusable getCurrentMonthDisplay helper so the statistikk view can show the selected month name
- ensure the statistics month picker falls back to a formatted name when the helper is unavailable
- turn the Oppsummering pill into an accessible button that scrolls down to the overview section

## Testing
- npm --workspace app run build *(fails: vite build cannot resolve @supabase/supabase-js in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6abb5f60832f947abe1645673ccc