### PR TITLE
Adjust abonnement layout spacing

### DIFF
--- a/app/src/css/settings.css
+++ b/app/src/css/settings.css
@@ -80,14 +80,16 @@ html.ios-pwa #shiftAddPage .tab-content {
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   min-height: calc(100vh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 140px);
-  padding: 20px 0;
+  padding-inline: 0;
+  padding-top: calc(var(--space-1) + env(safe-area-inset-top, 0px));
+  padding-bottom: calc(20px + env(safe-area-inset-bottom, 0px));
 }
 
 #abonnementPage .detail-title {
-  margin-bottom: 40px;
+  margin: var(--space-5) 0 var(--space-2);
   text-align: center;
 }
 

--- a/app/src/pages/abonnement.js
+++ b/app/src/pages/abonnement.js
@@ -19,11 +19,6 @@ function priceIdToTier(priceId) {
 function getAbonnementView() {
   return `
   <div id="abonnementPage" class="settings-page">
-    <div class="detail-title">
-      <h1>Abonnement</h1>
-      <p class="detail-subtitle">Få det meste ut av appen</p>
-    </div>
-
     <!-- Loading state -->
     <div class="modal-loading" id="abonnementLoading" style="display: flex; align-items: center; justify-content: center; min-height: 60vh;">
       <div class="loading-spinner" style="animation: spin 1s linear infinite;">
@@ -113,6 +108,11 @@ function getAbonnementView() {
       </div>
 
       <p class="carousel-disclaimer">Avbryt når som helst</p>
+
+      <div class="detail-title">
+        <h1>Abonnement</h1>
+        <p class="detail-subtitle">Få det meste ut av appen</p>
+      </div>
 
     </div>
 


### PR DESCRIPTION
## Summary
- reposition the abonnement carousel before the page header so it renders immediately under the navbar
- tweak the abonnement page spacing so the header sits lower while respecting safe-area padding for mobile users

## Testing
- npm --workspace app run build *(fails: missing optional dependency @supabase/supabase-js in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6dbd2350832faad70bcdb50920b1