### PR TITLE
Restore abonnement header placement and spacing

### DIFF
--- a/app/src/css/settings.css
+++ b/app/src/css/settings.css
@@ -80,14 +80,18 @@ html.ios-pwa #shiftAddPage .tab-content {
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  justify-content: flex-start;
+  align-items: stretch;
   min-height: calc(100vh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 140px);
-  padding: 20px 0;
+  padding-inline: 0;
+  padding-top: calc(var(--space-1) + env(safe-area-inset-top, 0px));
+  padding-bottom: calc(20px + env(safe-area-inset-bottom, 0px));
 }
 
 #abonnementPage .detail-title {
-  margin-bottom: 40px;
+  width: 100%;
+  padding: 0 var(--space-2);
+  margin: var(--space-6) 0 var(--space-1);
   text-align: center;
 }
 
@@ -96,6 +100,9 @@ html.ios-pwa #shiftAddPage .tab-content {
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: var(--space-2);
+  margin-top: calc(-1 * var(--space-1));
+  padding-top: var(--space-2);
 }
 
 #abonnementPage .detail-title h1 {


### PR DESCRIPTION
## Summary
- move the abonnement page heading back ahead of the subscription carousel so the title stays above the plan cards
- retune the abonnement layout spacing to stretch the container, pad the heading, and offset the carousel block for better thumb reach without reordering content

## Testing
- npm --workspace app run build *(fails: missing optional dependency @supabase/supabase-js in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6dbd2350832faad70bcdb50920b1